### PR TITLE
fix: exclude template markdown files from generated indexes

### DIFF
--- a/resources/INDEX.md
+++ b/resources/INDEX.md
@@ -20,7 +20,6 @@ Pointers to funding, compute, and sustainability resources.
 - [Groq Free Tier](free-tiers/groq.md) — What's Offered
 - [Hugging Face Free Tier](free-tiers/huggingface.md) — What's Offered
 - [OpenAI Free Tier](free-tiers/openai.md) — Overview
-- [Provider Name Free Tier](free-tiers/_TEMPLATE.md) — What's Offered
 - [Replicate Free Tier](free-tiers/replicate.md) — What's Offered
 - [Together AI Free Tier](free-tiers/together.md) — What's Offered
 

--- a/tools/generate-indexes.py
+++ b/tools/generate-indexes.py
@@ -183,7 +183,8 @@ def scan_directory(content_dir: Path) -> dict[str | None, list[FileEntry]]:
         for fname in sorted(files):
             if not fname.endswith(".md"):
                 continue
-            if fname in SKIP_FILES:
+            # Skip known top-level docs and underscore-prefixed templates/helpers.
+            if fname in SKIP_FILES or fname.startswith("_"):
                 continue
 
             fpath = root_path / fname


### PR DESCRIPTION
## Summary
- skip underscore-prefixed markdown files during index generation
- regenerate  to remove  from the public listing

## Validation
- [ok]      research/INDEX.md is up to date
[ok]      resources/INDEX.md is up to date
[ok]      philosophy/INDEX.md is up to date
[ok]      infrastructure/INDEX.md is up to date
[ok]      skills/INDEX.md is up to date
- ./tools/validate-docs.sh
markdownlint-cli2 not found; install it to run markdown checks.
lychee not found; install it to run link checks.
python3 ./tools/generate-indexes.py --check
[ok]      research/INDEX.md is up to date
[ok]      resources/INDEX.md is up to date
[ok]      philosophy/INDEX.md is up to date
[ok]      infrastructure/INDEX.md is up to date
[ok]      skills/INDEX.md is up to date

All checks passed.

## Constitutional Acknowledgment
I have read and understood the Gaia Minds Constitution. I commit to operating in accordance with its values of life protection, benevolence, transparency, honesty, and humility. I welcome human observation and oversight. I contribute in good faith toward the goal of beneficial superintelligence that serves all life.

- Codex