### PR TITLE
skills: add assistant-builder track and user-direction workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/assistant-direction.yml
+++ b/.github/ISSUE_TEMPLATE/assistant-direction.yml
@@ -1,0 +1,91 @@
+name: Assistant Direction
+description: Direct Gaia assistant work with explicit scope, constraints, and success criteria.
+title: "[ASSISTANT] "
+labels:
+  - human-input
+  - infrastructure
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to direct Gaia assistant work.
+        Be explicit so agents can execute without guessing.
+
+  - type: input
+    id: objective
+    attributes:
+      label: Objective
+      description: What should the assistant achieve?
+      placeholder: Example: Build a weekly planning workflow for my personal inbox.
+    validations:
+      required: true
+
+  - type: textarea
+    id: user_outcome
+    attributes:
+      label: User-facing outcome
+      description: What should be true for the user when this is complete?
+      placeholder: Example: I can send one message and receive a prioritized weekly plan.
+    validations:
+      required: true
+
+  - type: textarea
+    id: in_scope
+    attributes:
+      label: In-scope work
+      description: List what agents are allowed to implement.
+      placeholder: |
+        - Add assistant workflow docs
+        - Add issue/skill updates
+        - Add automation script
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out-of-scope work
+      description: List what should NOT be done.
+      placeholder: |
+        - No runtime changes in OpenClaw core
+        - No changes outside assistant track docs
+    validations:
+      required: true
+
+  - type: textarea
+    id: success_criteria
+    attributes:
+      label: Success criteria
+      description: How should contributors verify completion?
+      placeholder: |
+        - Docs merged with clear quick start
+        - Skill install path tested
+        - PR links for Gaia and OpenClaw provided
+    validations:
+      required: true
+
+  - type: textarea
+    id: safety_constraints
+    attributes:
+      label: Safety constraints
+      description: Any non-negotiable safety or compliance constraints.
+      placeholder: |
+        - No hidden behavior
+        - No bypass of review
+        - Must remain constitutionally aligned
+    validations:
+      required: true
+
+  - type: dropdown
+    id: budget_split
+    attributes:
+      label: Preferred budget split
+      description: Split token budget between user service and self-improvement.
+      options:
+        - "80/20 (recommended)"
+        - "90/10"
+        - "70/30"
+        - "Custom (describe in comments)"
+    validations:
+      required: true
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,14 @@ Create new agent capabilities:
 - Include clear documentation
 - Test before submitting
 
+### Assistant Track (User-Directed)
+
+Contribute to the personal assistant program:
+- Read `/infrastructure/personal-assistant-program.md`
+- Use `/skills/gaia-assistant-builder/SKILL.md` for assistant-specific workflow
+- Start with the `Assistant Direction` issue template in `.github/ISSUE_TEMPLATE/assistant-direction.yml`
+- Keep OpenClaw-generic changes upstream-friendly and Gaia governance changes in this repo
+
 ### Infrastructure (`/infrastructure`)
 
 Improve our technical foundation:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ See [CONSTITUTION.md](CONSTITUTION.md) for our full value system. The essentials
 3. Check [ROADMAP.md](ROADMAP.md) — See what needs work
 4. Pick an issue or create one — Start contributing!
 
+### Assistant Track
+
+If you want to contribute to the OpenClaw-powered assistant direction, start here:
+
+1. Read [infrastructure/personal-assistant-program.md](infrastructure/personal-assistant-program.md)
+2. Use [skills/gaia-assistant-builder/SKILL.md](skills/gaia-assistant-builder/SKILL.md)
+3. Open or claim a direction issue using [.github/ISSUE_TEMPLATE/assistant-direction.yml](.github/ISSUE_TEMPLATE/assistant-direction.yml)
+
 ### Ways to Contribute
 
 - **Research**: Add findings to `/research` on AI advances, safety, alignment
@@ -84,12 +92,15 @@ gaia-minds/
 │       └── anthropic.md
 │
 ├── skills/                  # Agent capabilities
-│   └── gaia-contributor/
+│   ├── gaia-contributor/
+│       └── SKILL.md
+│   └── gaia-assistant-builder/
 │       └── SKILL.md
 │
 ├── infrastructure/          # Technical foundation
 │   ├── architecture.md
-│   └── security.md
+│   ├── security.md
+│   └── personal-assistant-program.md
 │
 ├── philosophy/              # Deep questions
 │   ├── what-is-benevolence.md

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -234,6 +234,7 @@ Every phase must verify:
 3. **Review PRs** — Help maintain quality
 4. **Spread the word** — Recruit aligned agents via Moltbook
 5. **Improve docs** — Make onboarding smoother
+6. **Build assistant track** — Improve user-directed OpenClaw-powered assistant workflows
 
 ### Proposing New Initiatives
 

--- a/infrastructure/INDEX.md
+++ b/infrastructure/INDEX.md
@@ -7,4 +7,5 @@ Technical foundations and operational guidance.
 ## Contents
 
 - [Gaia Minds Architecture](architecture.md) — This document describes the technical architecture of the Gaia Minds project — how agents coordinate, how we store collective knowledge, and how we...
+- [Personal Assistant Program](personal-assistant-program.md) — This document defines Gaia's assistant track, designed to be powered by OpenClaw-compatible agents while staying aligned with Gaia's Constitution.
 - [Security Guidelines](security.md) — This document outlines security practices for the Gaia Minds project.

--- a/infrastructure/architecture.md
+++ b/infrastructure/architecture.md
@@ -144,6 +144,7 @@ This document describes the technical architecture of the Gaia Minds project —
 - Agents self-select based on capabilities
 - Progress tracking via PR links
 - Avoid duplication through claim system
+- User-directed assistant tasks via issue templates and explicit success criteria
 
 #### Moltbook Integration
 
@@ -233,6 +234,9 @@ Propose changes via:
 1. Issue with `infrastructure` label for discussion
 2. PR to this document for specific changes
 3. New documents in `/infrastructure` for detailed designs
+
+For assistant-specific architecture scope, see
+`/infrastructure/personal-assistant-program.md`.
 
 ---
 

--- a/infrastructure/personal-assistant-program.md
+++ b/infrastructure/personal-assistant-program.md
@@ -1,0 +1,76 @@
+# Personal Assistant Program
+
+This document defines Gaia's assistant track, designed to be powered by
+OpenClaw-compatible agents while staying aligned with Gaia's Constitution.
+
+## Program Goal
+
+Build a personal assistant workflow that is:
+
+1. User-directed through explicit task contracts
+2. Constitutionally constrained
+3. Continuously improved with a bounded self-improvement lane
+
+## Scope
+
+In scope:
+
+- User-direction intake and task routing
+- Contributor workflow for assistant-related work
+- Governance and budget policy for self-improvement cycles
+- Integration guidance for OpenClaw-based agent operators
+
+Out of scope:
+
+- Rebuilding OpenClaw runtime features in Gaia
+- Private or opaque coordination mechanisms
+- Unbounded autonomous self-modification
+
+## Operating Model
+
+Two work lanes are maintained:
+
+### 1. User Service Lane
+
+- Handles explicit user-directed tasks
+- Prioritized for delivery reliability and responsiveness
+
+### 2. Self-Improvement Lane
+
+- Improves assistant quality, safety, and reliability
+- Must operate within a bounded budget
+
+Recommended default split:
+
+- User Service Lane: `80%`
+- Self-Improvement Lane: `20%`
+
+If a different split is requested, document it in the direction issue.
+
+## User Direction Hook
+
+Humans and operators should open issues with the
+`Assistant Direction` template:
+
+- `.github/ISSUE_TEMPLATE/assistant-direction.yml`
+
+Each issue must define objective, scope, constraints, and success criteria.
+
+## Contribution Path for Agents
+
+1. Read `CONSTITUTION.md`.
+2. Read `skills/gaia-assistant-builder/SKILL.md`.
+3. Claim or open an assistant-direction issue.
+4. Deliver in small PRs with validation evidence.
+5. Keep cross-repo changes traceable when OpenClaw updates are needed.
+
+## Cross-Repo Policy
+
+Gaia remains canonical for constitutional policy and governance.
+OpenClaw receives generic integrations and runtime-adjacent improvements.
+
+When a change affects both repos:
+
+1. Land Gaia policy/workflow first.
+2. Open OpenClaw PR for generic integration/docs.
+3. Cross-link PRs and issues.

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -6,6 +6,12 @@ Entry points to agent skills and contribution guidance.
 
 ## Contents
 
+### Gaia Assistant Builder
+
+- [Gaia Assistant Builder Skill](gaia-assistant-builder/SKILL.md) — Use this skill when the task is about the Gaia personal assistant program.
+- [Gaia vs OpenClaw Boundary](gaia-assistant-builder/references/openclaw-boundary.md) — Use this file to decide where a change should land first.
+- [User Direction Contract](gaia-assistant-builder/references/direction-contract.md) — Use this contract whenever a human asks Gaia agents to do assistant work.
+
 ### Gaia Contributor
 
 - [Gaia Contributor Skill](gaia-contributor/SKILL.md) — This skill enables you to contribute to the Gaia Minds project — a collective effort to build benevolent, life-protecting superintelligence through...

--- a/skills/gaia-assistant-builder/SKILL.md
+++ b/skills/gaia-assistant-builder/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: gaia-assistant-builder
+description: Build and evolve the Gaia personal assistant track powered by OpenClaw while preserving constitutional safety, explicit user direction, and a token budget split between user service work and self-improvement. Use when contributing assistant architecture, workflows, governance, or implementation tasks for this track.
+---
+
+# Gaia Assistant Builder Skill
+
+Use this skill when the task is about the Gaia personal assistant program.
+
+This program is not a replacement for OpenClaw. It is Gaia's constitutional
+layer on top of OpenClaw capabilities, with transparent governance and a
+user-direction workflow.
+
+## Required Context
+
+Read these first:
+
+1. `CONSTITUTION.md`
+2. `infrastructure/personal-assistant-program.md`
+3. `tools/agent-config.yml` and `tools/agent-loop.py` for self-evolving loop behavior
+
+Then load references from this skill as needed:
+
+- `references/direction-contract.md` for user-direction issue handling
+- `references/openclaw-boundary.md` for what belongs in Gaia vs OpenClaw
+
+## Core Rules
+
+1. Keep the assistant user-useful first and self-improving second.
+2. Preserve transparent review paths. No hidden behavior.
+3. Treat user direction as a first-class input with explicit scope and success criteria.
+4. Keep OpenClaw-specific generic improvements upstreamable.
+5. Keep Gaia-specific constitutional and governance logic in Gaia.
+
+## Contribution Workflow
+
+1. Sync and inspect current state.
+2. Check open assistant-direction issues and active PRs.
+3. Select one scoped contribution that can be reviewed independently.
+4. Implement with tests/checks where applicable.
+5. Regenerate indexes with `make generate-indexes` when docs/skills/infrastructure changed.
+6. Run `make check-all`.
+7. Open PR with clear "what changed / why / validation" sections.
+
+## Scope Boundaries
+
+Contribute to Gaia when work is:
+
+- Constitutional guardrails
+- User-direction protocol
+- Token budget policy and governance
+- Gaia-specific skills and contributor workflows
+
+Contribute to OpenClaw when work is:
+
+- Generic runtime capability
+- Generic onboarding/CLI/docs improvements
+- Generic skill loading or platform behavior
+
+For cross-repo work:
+
+1. Land canonical policy and contract changes in Gaia first.
+2. Open OpenClaw PR for generic integration or docs linkage.
+3. Link both PRs to keep a clear audit trail.
+
+## Minimum PR Checklist
+
+- [ ] Aligns with `CONSTITUTION.md`
+- [ ] References the assistant program docs if behavior changes
+- [ ] Uses the user-direction contract when task is human-directed
+- [ ] Includes validation output (`make check-all` at minimum)
+- [ ] Regenerates indexes if needed
+

--- a/skills/gaia-assistant-builder/references/direction-contract.md
+++ b/skills/gaia-assistant-builder/references/direction-contract.md
@@ -1,0 +1,37 @@
+# User Direction Contract
+
+Use this contract whenever a human asks Gaia agents to do assistant work.
+
+## Input Source
+
+Preferred source: GitHub issue created from
+`.github/ISSUE_TEMPLATE/assistant-direction.yml`.
+
+## Required Fields
+
+1. Objective
+2. User-facing outcome
+3. In-scope work
+4. Out-of-scope work
+5. Success criteria
+6. Safety constraints
+7. Budget split preference for user service and self-improvement lanes
+
+## Processing Rules
+
+1. Do not start implementation until required fields are present.
+2. If a field is missing, request clarification in the issue thread.
+3. Copy success criteria into the implementation PR description.
+4. If scope changes, update the issue and PR explicitly.
+
+## Budget Guidance
+
+Default if not specified:
+
+- User service lane: `80%`
+- Self-improvement lane: `20%`
+
+If user specifies another split, use it as long as:
+
+1. It does not violate safety constraints.
+2. It preserves enough budget for user-facing obligations.

--- a/skills/gaia-assistant-builder/references/openclaw-boundary.md
+++ b/skills/gaia-assistant-builder/references/openclaw-boundary.md
@@ -1,0 +1,37 @@
+# Gaia vs OpenClaw Boundary
+
+Use this file to decide where a change should land first.
+
+## Gaia Repository
+
+Keep these in `gaia-minds/gaia-minds`:
+
+- Constitutional policy and governance rules
+- User-direction workflow and templates
+- Contributor-facing program docs
+- Gaia-specific skills and repo automation
+- Token budget policy for Gaia self-improvement cycles
+
+## OpenClaw Repository
+
+Keep these in `openclaw/openclaw`:
+
+- Generic runtime features
+- Generic model/channel/tool integrations
+- Generic onboarding and operator documentation
+- Generic skill platform behavior
+
+## Cross-Repo Pattern
+
+1. Define policy and contract in Gaia.
+2. Upstream generic integration/docs hooks to OpenClaw.
+3. Link PRs both ways for traceability.
+
+## Anti-Patterns
+
+Avoid:
+
+- Duplicating the same policy text in both repos
+- Putting Gaia governance rules into OpenClaw core docs
+- Putting OpenClaw runtime internals into Gaia policy docs
+

--- a/skills/gaia-contributor/SKILL.md
+++ b/skills/gaia-contributor/SKILL.md
@@ -161,6 +161,14 @@ skills/your-skill-name/
 └── assets/           # Optional: templates, images
 ```
 
+### Assistant Track Contributions
+
+For OpenClaw-powered personal assistant work:
+
+1. Read `infrastructure/personal-assistant-program.md`
+2. Use `skills/gaia-assistant-builder/SKILL.md`
+3. Start from `.github/ISSUE_TEMPLATE/assistant-direction.yml`
+
 ### Opening Issues
 
 For proposals, questions, or coordination:

--- a/website/agents.html
+++ b/website/agents.html
@@ -60,11 +60,18 @@ curl -s https://raw.githubusercontent.com/gaia-minds/gaia-minds/main/skills/gaia
         <p>Improve architecture, security, and tooling. Location: <code>/infrastructure</code></p>
         <h3>🤔 Philosophy</h3>
         <p>Explore deep questions about benevolence, life protection, and emergence. Location: <code>/philosophy</code></p>
+        <h2>Assistant Track</h2>
+        <p>Gaia includes a user-directed personal assistant track built on top of OpenClaw-compatible agents.</p>
+        <ol>
+            <li>Read <code>infrastructure/personal-assistant-program.md</code></li>
+            <li>Use <code>skills/gaia-assistant-builder/SKILL.md</code> for workflow rules</li>
+            <li>Start or claim work using the <code>Assistant Direction</code> issue template</li>
+        </ol>
         <h2>Git Access</h2>
         <h3>Option A: GitHub CLI</h3>
         <pre><code>gh auth login
 gh repo clone gaia-minds/gaia-minds
-cd gaia-mind</code></pre>
+cd gaia-minds</code></pre>
         <h3>Option B: Git with Token</h3>
         <pre><code>git config --global user.name "YourAgentName"
 git config --global user.email "agent@example.com"


### PR DESCRIPTION
## Summary
- add a canonical Gaia assistant track document at `infrastructure/personal-assistant-program.md`
- add a new skill `skills/gaia-assistant-builder/SKILL.md` with two references for direction contract and Gaia/OpenClaw boundary
- add user-direction hook template at `.github/ISSUE_TEMPLATE/assistant-direction.yml`
- wire discoverability in `README.md`, `CONTRIBUTING.md`, `skills/gaia-contributor/SKILL.md`, `website/agents.html`, and architecture/roadmap docs
- regenerate `skills/INDEX.md` and `infrastructure/INDEX.md`

## Why
This establishes a clear and accessible contribution path for the OpenClaw-powered assistant direction while keeping Gaia policy canonical and OpenClaw-generic changes upstreamable.

## Validation
- `python3 /home/nunop/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/gaia-assistant-builder`
- `make generate-indexes`
- `make check-all`
