### PR TITLE
feat: add standalone Gaia assistant and dual-track evolution config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,14 @@ This symlinks `tools/pre-commit` into `.git/hooks/`. On every `git commit`, it a
 make check-all
 ```
 
+### Run standalone Gaia assistant bootstrap and health checks
+
+```bash
+make assistant-init
+make assistant-doctor
+make assistant-run-dry
+```
+
 ## Architecture
 
 The repository is organized into knowledge domains, each with its own directory:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,7 @@ Create new agent capabilities:
 
 Contribute to the personal assistant program:
 - Read `/infrastructure/personal-assistant-program.md`
+- Read `/assistant/README.md` for standalone runtime bootstrap
 - Use `/skills/gaia-assistant-builder/SKILL.md` for assistant-specific workflow
 - Start with the `Assistant Direction` issue template in `.github/ISSUE_TEMPLATE/assistant-direction.yml`
 - Keep OpenClaw-generic changes upstream-friendly and Gaia governance changes in this repo

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs-check verify-resources generate-indexes check-indexes check-all install-hooks uninstall-hooks
+.PHONY: docs-check verify-resources generate-indexes check-indexes check-all install-hooks uninstall-hooks assistant-init assistant-doctor assistant-run-dry
 
 docs-check:
 	./tools/validate-docs.sh
@@ -23,3 +23,12 @@ install-hooks:
 uninstall-hooks:
 	@rm -f .git/hooks/pre-commit
 	@echo "Pre-commit hook removed."
+
+assistant-init:
+	python3 ./tools/gaia-assistant.py init
+
+assistant-doctor:
+	python3 ./tools/gaia-assistant.py doctor
+
+assistant-run-dry:
+	python3 ./tools/gaia-assistant.py run --mode single --dry-run

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ If you want to contribute to the OpenClaw-powered assistant direction, start her
 2. Use [skills/gaia-assistant-builder/SKILL.md](skills/gaia-assistant-builder/SKILL.md)
 3. Open or claim a direction issue using [.github/ISSUE_TEMPLATE/assistant-direction.yml](.github/ISSUE_TEMPLATE/assistant-direction.yml)
 
+### Standalone Runtime
+
+Gaia now includes a standalone personal assistant launcher:
+
+1. Read [assistant/README.md](assistant/README.md)
+2. Initialize and check environment:
+   `python3 tools/gaia-assistant.py init && python3 tools/gaia-assistant.py doctor`
+3. Run a cycle:
+   `python3 tools/gaia-assistant.py run --mode single --dry-run`
+
 ### Ways to Contribute
 
 - **Research**: Add findings to `/research` on AI advances, safety, alignment
@@ -101,6 +111,9 @@ gaia-minds/
 │   ├── architecture.md
 │   ├── security.md
 │   └── personal-assistant-program.md
+│
+├── assistant/               # Standalone assistant runtime docs
+│   └── README.md
 │
 ├── philosophy/              # Deep questions
 │   ├── what-is-benevolence.md

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -1,0 +1,51 @@
+# Gaia Standalone Assistant
+
+This is the standalone Gaia personal assistant runtime path.
+
+It runs independently from OpenClaw, while staying compatible with the same
+provider auth patterns:
+
+1. Subscription OAuth flows (for providers that support it in your environment)
+2. Direct API key access
+
+## Quick Start
+
+```bash
+# From this repository
+python3 tools/gaia-assistant.py init
+python3 tools/gaia-assistant.py doctor
+
+# Single dry-run cycle
+python3 tools/gaia-assistant.py run --mode single --dry-run
+
+# Continuous assistant track
+python3 tools/gaia-assistant.py run --mode continuous --track assistant
+```
+
+## Tracks
+
+The evolution loop runs with two tracks:
+
+1. `assistant` — user-facing personal assistant improvements
+2. `framework` — evolution framework and governance improvements
+
+Default scheduling and policy live in `tools/agent-config.yml`.
+
+## Budget Policy
+
+Default budget split:
+
+- User service: `80%`
+- Self-improvement: `20%`
+
+Adjust in `tools/agent-config.yml` under `budget`.
+
+## Auth Notes
+
+Expected environment variables for direct API mode:
+
+- `ANTHROPIC_API_KEY`
+- `OPENAI_API_KEY`
+
+Provider OAuth profile support depends on your operator environment.
+

--- a/infrastructure/personal-assistant-program.md
+++ b/infrastructure/personal-assistant-program.md
@@ -19,12 +19,22 @@ In scope:
 - Contributor workflow for assistant-related work
 - Governance and budget policy for self-improvement cycles
 - Integration guidance for OpenClaw-based agent operators
+- Standalone Gaia personal assistant runtime bootstrap
 
 Out of scope:
 
 - Rebuilding OpenClaw runtime features in Gaia
 - Private or opaque coordination mechanisms
 - Unbounded autonomous self-modification
+
+## Runtime Modes
+
+Gaia assistant supports two operational modes:
+
+1. Standalone mode (Gaia runtime via `tools/gaia-assistant.py`)
+2. OpenClaw-powered mode (Gaia policy/skills on top of OpenClaw runtime)
+
+Standalone quick start is documented in `assistant/README.md`.
 
 ## Operating Model
 
@@ -46,6 +56,9 @@ Recommended default split:
 - Self-Improvement Lane: `20%`
 
 If a different split is requested, document it in the direction issue.
+
+Track scheduling and allowed action policies are defined in
+`tools/agent-config.yml` under `evolution`.
 
 ## User Direction Hook
 

--- a/skills/gaia-assistant-builder/SKILL.md
+++ b/skills/gaia-assistant-builder/SKILL.md
@@ -17,7 +17,8 @@ Read these first:
 
 1. `CONSTITUTION.md`
 2. `infrastructure/personal-assistant-program.md`
-3. `tools/agent-config.yml` and `tools/agent-loop.py` for self-evolving loop behavior
+3. `assistant/README.md` for standalone runtime bootstrap
+4. `tools/agent-config.yml` and `tools/agent-loop.py` for self-evolving loop behavior
 
 Then load references from this skill as needed:
 
@@ -70,4 +71,3 @@ For cross-repo work:
 - [ ] Uses the user-direction contract when task is human-directed
 - [ ] Includes validation output (`make check-all` at minimum)
 - [ ] Regenerates indexes if needed
-

--- a/tools/agent-config.yml
+++ b/tools/agent-config.yml
@@ -35,6 +35,44 @@ cycle:
   max_cycles: 0  # 0 = unlimited
 
 # ---------------------------------------------------------------------------
+# Evolution tracks (assistant vs framework)
+# ---------------------------------------------------------------------------
+evolution:
+  scheduler: "weighted_round_robin"  # weighted_round_robin | round_robin
+  tracks:
+    assistant:
+      weight: 7
+      description: "Improve user-facing personal assistant behavior and reliability"
+      allowed_actions:
+        - "verify_resources"
+        - "generate_indexes"
+        - "add_research"
+        - "add_resource"
+        - "update_skill"
+        - "open_issue"
+        - "comment_on_pr"
+        - "check_pr_status"
+    framework:
+      weight: 3
+      description: "Improve Gaia self-evolving framework and governance tooling"
+      allowed_actions:
+        - "verify_resources"
+        - "generate_indexes"
+        - "create_tool"
+        - "update_skill"
+        - "open_issue"
+        - "comment_on_pr"
+        - "check_pr_status"
+
+# ---------------------------------------------------------------------------
+# Budget policy
+# ---------------------------------------------------------------------------
+budget:
+  user_service_pct: 80
+  self_improvement_pct: 20
+  hard_cycle_token_cap: 12000
+
+# ---------------------------------------------------------------------------
 # Risk classification for auto-execution vs PR
 # ---------------------------------------------------------------------------
 risk:

--- a/tools/agent-loop.py
+++ b/tools/agent-loop.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sys
 import time
 from datetime import datetime, timezone
@@ -79,6 +80,43 @@ LOG_FORMAT = "%(asctime)s [%(levelname)s] %(message)s"
 LOG_DATE_FORMAT = "%H:%M:%S"
 
 log = logging.getLogger("gaia-agent")
+
+# Defaults for dual-track evolution behavior.
+DEFAULT_TRACKS: Dict[str, Dict[str, Any]] = {
+    "assistant": {
+        "weight": 7,
+        "description": "Improve user-facing personal assistant behavior and reliability",
+        "allowed_actions": [
+            "verify_resources",
+            "generate_indexes",
+            "add_research",
+            "add_resource",
+            "update_skill",
+            "open_issue",
+            "comment_on_pr",
+            "check_pr_status",
+        ],
+    },
+    "framework": {
+        "weight": 3,
+        "description": "Improve Gaia self-evolving framework and governance tooling",
+        "allowed_actions": [
+            "verify_resources",
+            "generate_indexes",
+            "create_tool",
+            "update_skill",
+            "open_issue",
+            "comment_on_pr",
+            "check_pr_status",
+        ],
+    },
+}
+
+DEFAULT_BUDGET_POLICY: Dict[str, Any] = {
+    "user_service_pct": 80,
+    "self_improvement_pct": 20,
+    "hard_cycle_token_cap": 12000,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -159,11 +197,13 @@ def log_decision(
     alignment: AlignmentResult,
     outcome: str,
     details: str = "",
+    active_track: str = "unknown",
 ) -> None:
     """Append a decision record to decisions.jsonl."""
     record = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "cycle": cycle,
+        "track": active_track,
         "action": action.get("type", "unknown"),
         "action_params": action.get("params", {}),
         "reasoning": alignment.reasoning[:500],
@@ -189,7 +229,12 @@ def log_lesson(cycle: int, lesson: str, source: str, context: str = "") -> None:
         f.write(json.dumps(record) + "\n")
 
 
-def update_state(cycle: int, results: List[ActionResult]) -> None:
+def update_state(
+    cycle: int,
+    results: List[ActionResult],
+    active_track: str = "unknown",
+    budget_policy: Optional[Dict[str, Any]] = None,
+) -> None:
     """Update state.json with cycle results."""
     state = {}
     if STATE_PATH.exists():
@@ -200,7 +245,13 @@ def update_state(cycle: int, results: List[ActionResult]) -> None:
 
     state["last_cycle"] = cycle
     state["last_run"] = datetime.now(timezone.utc).isoformat()
+    state["last_track"] = active_track
     state["total_actions"] = state.get("total_actions", 0) + len(results)
+    track_counts = state.get("track_counts", {})
+    track_counts[active_track] = track_counts.get(active_track, 0) + 1
+    state["track_counts"] = track_counts
+    if budget_policy:
+        state["budget_policy"] = budget_policy
 
     for r in results:
         if r.artifacts.get("pr_url"):
@@ -256,6 +307,86 @@ def rotate_logs(config: Dict[str, Any]) -> None:
             log.info("Rotated %s: kept last %d of %d entries", path.name, limit, len(lines))
 
 
+def normalized_track_config(config: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Return normalized track configuration with safe defaults."""
+    tracks_cfg = config.get("evolution", {}).get("tracks", {})
+    out: Dict[str, Dict[str, Any]] = {}
+    for name, defaults in DEFAULT_TRACKS.items():
+        configured = tracks_cfg.get(name, {})
+        weight = configured.get("weight", defaults["weight"])
+        try:
+            weight_int = int(weight)
+        except (TypeError, ValueError):
+            weight_int = int(defaults["weight"])
+        if weight_int < 1:
+            weight_int = 1
+        allowed_actions = configured.get("allowed_actions", defaults["allowed_actions"])
+        if not isinstance(allowed_actions, list):
+            allowed_actions = defaults["allowed_actions"]
+        out[name] = {
+            "weight": weight_int,
+            "description": configured.get("description", defaults["description"]),
+            "allowed_actions": allowed_actions,
+        }
+    return out
+
+
+def normalized_budget_policy(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Return normalized budget policy with safe defaults."""
+    budget_cfg = config.get("budget", {})
+    out = dict(DEFAULT_BUDGET_POLICY)
+    out.update(budget_cfg if isinstance(budget_cfg, dict) else {})
+    for key in ("user_service_pct", "self_improvement_pct", "hard_cycle_token_cap"):
+        try:
+            out[key] = int(out[key])
+        except (TypeError, ValueError):
+            out[key] = DEFAULT_BUDGET_POLICY[key]
+    if out["user_service_pct"] < 0:
+        out["user_service_pct"] = DEFAULT_BUDGET_POLICY["user_service_pct"]
+    if out["self_improvement_pct"] < 0:
+        out["self_improvement_pct"] = DEFAULT_BUDGET_POLICY["self_improvement_pct"]
+    if out["hard_cycle_token_cap"] < 1:
+        out["hard_cycle_token_cap"] = DEFAULT_BUDGET_POLICY["hard_cycle_token_cap"]
+    return out
+
+
+def select_active_track(
+    config: Dict[str, Any],
+    cycle_number: int,
+) -> str:
+    """Choose active track for this cycle.
+
+    Override via GAIA_ACTIVE_TRACK_OVERRIDE=assistant|framework.
+    """
+    tracks = normalized_track_config(config)
+    override = os.environ.get("GAIA_ACTIVE_TRACK_OVERRIDE", "").strip().lower()
+    if override in tracks:
+        return override
+
+    scheduler = config.get("evolution", {}).get("scheduler", "weighted_round_robin")
+    if scheduler == "round_robin":
+        order = sorted(tracks.keys())
+        return order[(cycle_number - 1) % len(order)]
+
+    # weighted_round_robin
+    weighted_order: List[str] = []
+    for name in sorted(tracks.keys()):
+        weighted_order.extend([name] * int(tracks[name]["weight"]))
+    if not weighted_order:
+        return "assistant"
+    return weighted_order[(cycle_number - 1) % len(weighted_order)]
+
+
+def action_allowed_in_track(action_type: str, active_track: str, config: Dict[str, Any]) -> bool:
+    """Return whether action_type is allowed in the active track policy."""
+    tracks = normalized_track_config(config)
+    track_cfg = tracks.get(active_track)
+    if not track_cfg:
+        return False
+    allowed_actions = track_cfg.get("allowed_actions", [])
+    return action_type in allowed_actions
+
+
 # ---------------------------------------------------------------------------
 # Claude reasoning
 # ---------------------------------------------------------------------------
@@ -292,6 +423,7 @@ IMPORTANT RULES:
 - If nothing needs doing, return an empty actions list. Don't invent busywork.
 - Learn from past mistakes shown in the memory context.
 - Be specific in your reasoning — reference what you observed in the state.
+- Respect the active evolution track and only propose actions allowed for that track.
 """
 
 USER_PROMPT_TEMPLATE = """\
@@ -306,6 +438,15 @@ Lessons learned:
 
 Agent state:
 {agent_state_json}
+
+Active evolution track for this cycle:
+{active_track}
+
+Track policy:
+{track_policy_json}
+
+Budget policy:
+{budget_policy_json}
 
 Based on the current state, what actions should I take this cycle?
 
@@ -345,6 +486,7 @@ def ask_claude_for_plan(
     state: RepoState,
     memory: Dict[str, Any],
     constitution: str,
+    active_track: str,
 ) -> Dict[str, Any]:
     """Ask Claude to analyze state and propose actions."""
     reasoning_config = config.get("reasoning", {})
@@ -356,12 +498,17 @@ def ask_claude_for_plan(
 
     n_decisions = 10
     n_lessons = 10
+    track_policy = normalized_track_config(config).get(active_track, {})
+    budget_policy = normalized_budget_policy(config)
     user_prompt = USER_PROMPT_TEMPLATE.format(
         state_json=json.dumps(state_to_summary(state), indent=2),
         n_decisions=n_decisions,
         decisions_json=json.dumps(memory.get("recent_decisions", []), indent=2),
         lessons_json=json.dumps(memory.get("lessons", []), indent=2),
         agent_state_json=json.dumps(memory.get("state", {}), indent=2),
+        active_track=active_track,
+        track_policy_json=json.dumps(track_policy, indent=2),
+        budget_policy_json=json.dumps(budget_policy, indent=2),
     )
 
     log.info("Asking Claude (%s) for a plan...", model)
@@ -421,6 +568,7 @@ def run_cycle(
 ) -> List[ActionResult]:
     """Run one complete agent cycle."""
     repo_root = str(REPO_ROOT)
+    budget_policy = normalized_budget_policy(config)
 
     # 1. Gather state
     log.info("=== Cycle %d: Gathering state ===", cycle_number)
@@ -428,6 +576,14 @@ def run_cycle(
 
     # 2. Load memory
     memory = load_memory()
+    active_track = select_active_track(config, cycle_number)
+    log.info(
+        "Active track: %s (budget split: service=%s%%, self_improvement=%s%%, hard_cycle_token_cap=%s)",
+        active_track,
+        budget_policy["user_service_pct"],
+        budget_policy["self_improvement_pct"],
+        budget_policy["hard_cycle_token_cap"],
+    )
 
     # 3. Load constitution
     constitution = load_constitution(repo_root)
@@ -435,14 +591,14 @@ def run_cycle(
     # 4. Ask Claude for a plan
     if client is None:
         log.info("No Anthropic client available -- skipping Claude reasoning (dry-run)")
-        plan = {"reasoning": "No API client (dry-run without SDK/key)", "actions": []}
+        plan = {"reasoning": f"No API client (dry-run without SDK/key), active_track={active_track}", "actions": []}
     else:
-        plan = ask_claude_for_plan(client, config, state, memory, constitution)
+        plan = ask_claude_for_plan(client, config, state, memory, constitution, active_track)
 
     actions = plan.get("actions", [])
     if not actions:
         log.info("No actions proposed this cycle.")
-        update_state(cycle_number, [])
+        update_state(cycle_number, [], active_track, budget_policy)
         return []
 
     # 5. Process each action
@@ -450,6 +606,24 @@ def run_cycle(
     for i, action in enumerate(actions):
         action_type = action.get("type", "unknown")
         log.info("--- Action %d/%d: %s ---", i + 1, len(actions), action_type)
+
+        if not action_allowed_in_track(action_type, active_track, config):
+            reason = f"Action '{action_type}' blocked by track policy for '{active_track}'"
+            log.warning(reason)
+            track_policy_alignment = AlignmentResult(
+                allowed=False,
+                risk_level="high",
+                reasoning=reason,
+            )
+            log_decision(
+                cycle_number,
+                action,
+                track_policy_alignment,
+                "blocked_by_track_policy",
+                reason,
+                active_track=active_track,
+            )
+            continue
 
         # 5a. Check alignment
         alignment = check_alignment(
@@ -470,12 +644,12 @@ def run_cycle(
         # 5b. Route based on alignment + risk
         if not alignment.allowed:
             log.warning("Action BLOCKED by alignment checker")
-            log_decision(cycle_number, action, alignment, "blocked")
+            log_decision(cycle_number, action, alignment, "blocked", active_track=active_track)
             continue
 
         if alignment.risk_level == "forbidden":
             log.warning("Action FORBIDDEN")
-            log_decision(cycle_number, action, alignment, "forbidden")
+            log_decision(cycle_number, action, alignment, "forbidden", active_track=active_track)
             continue
 
         if alignment.risk_level == "high":
@@ -502,13 +676,19 @@ def run_cycle(
                 }
                 result = execute_action(issue_action, config, repo_root)
                 results.append(result)
-            log_decision(cycle_number, action, alignment, "deferred_to_human")
+            log_decision(
+                cycle_number,
+                action,
+                alignment,
+                "deferred_to_human",
+                active_track=active_track,
+            )
             continue
 
         # 5c. Execute (low or medium risk)
         if dry_run:
             log.info("[DRY RUN] Would execute: %s", action_type)
-            log_decision(cycle_number, action, alignment, "dry_run")
+            log_decision(cycle_number, action, alignment, "dry_run", active_track=active_track)
             continue
 
         log.info("Executing action...")
@@ -518,7 +698,14 @@ def run_cycle(
         outcome = "success" if result.success else "failed"
         log.info("Result: %s - %s", outcome, result.output[:200] if result.output else result.error[:200])
 
-        log_decision(cycle_number, action, alignment, outcome, result.output or result.error)
+        log_decision(
+            cycle_number,
+            action,
+            alignment,
+            outcome,
+            result.output or result.error,
+            active_track=active_track,
+        )
 
         # Learn from failures
         if not result.success:
@@ -530,7 +717,7 @@ def run_cycle(
             )
 
     # 6. Update state
-    update_state(cycle_number, results)
+    update_state(cycle_number, results, active_track, budget_policy)
 
     # 7. Rotate logs if needed
     rotate_logs(config)
@@ -638,8 +825,6 @@ def main() -> int:
         return 1
 
     # Check for API key (not needed in dry-run)
-    import os
-
     if not os.environ.get("ANTHROPIC_API_KEY") and not args.dry_run:
         log.error(
             "ANTHROPIC_API_KEY environment variable is not set.\n"

--- a/tools/gaia-assistant.py
+++ b/tools/gaia-assistant.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Standalone Gaia personal assistant launcher.
+
+This wrapper makes it easier for users to run Gaia's dual-track evolution loop
+as a personal assistant runtime without OpenClaw as a hard dependency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+DEFAULT_HOME = Path(os.environ.get("GAIA_ASSISTANT_HOME", str(Path.home() / ".gaia-assistant"))).expanduser()
+DEFAULT_STATE_DIR = DEFAULT_HOME / "state"
+DEFAULT_CONFIG_PATH = DEFAULT_HOME / "config.json"
+AGENT_CONFIG_PATH = SCRIPT_DIR / "agent-config.yml"
+AGENT_LOOP_PATH = SCRIPT_DIR / "agent-loop.py"
+
+
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "runtime": {
+        "mode": "continuous",
+        "interval_minutes": 60,
+    },
+    "auth": {
+        "providers": {
+            "anthropic": {
+                "subscription_oauth_supported": True,
+                "api_key_env": "ANTHROPIC_API_KEY",
+            },
+            "openai": {
+                "subscription_oauth_supported": True,
+                "api_key_env": "OPENAI_API_KEY",
+            },
+        }
+    },
+    "tracks": {
+        "default": "auto",
+    },
+}
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+
+
+def _write_json(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    cfg_path = Path(args.config).expanduser()
+    state_dir = Path(args.state_dir).expanduser()
+    try:
+        state_dir.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        print(
+            "Cannot create state directory due to permissions. "
+            "Set GAIA_ASSISTANT_HOME or pass --state-dir to a writable path.",
+            file=sys.stderr,
+        )
+        return 1
+    if cfg_path.exists() and not args.force:
+        print(
+            f"Config already exists at {cfg_path}. Use --force to overwrite.",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        _write_json(cfg_path, DEFAULT_CONFIG)
+    except PermissionError:
+        print(
+            "Cannot write config due to permissions. "
+            "Set GAIA_ASSISTANT_HOME or pass --config to a writable path.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Initialized Gaia assistant config: {cfg_path}")
+    print(f"Initialized Gaia assistant state dir: {state_dir}")
+    return 0
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    _ = args
+    problems = 0
+    required_cmds = ["python3", "git"]
+    optional_cmds = ["gh"]
+
+    print("Gaia assistant doctor")
+    print("====================")
+
+    for name in required_cmds:
+        if shutil.which(name):
+            print(f"[ok] required command found: {name}")
+        else:
+            problems += 1
+            print(f"[missing] required command not found: {name}")
+
+    for name in optional_cmds:
+        if shutil.which(name):
+            print(f"[ok] optional command found: {name}")
+        else:
+            print(f"[warn] optional command not found: {name}")
+
+    anth = os.environ.get("ANTHROPIC_API_KEY")
+    oai = os.environ.get("OPENAI_API_KEY")
+    if anth or oai:
+        print("[ok] at least one API auth env var is present")
+    else:
+        print("[warn] no API key env vars found (ANTHROPIC_API_KEY / OPENAI_API_KEY)")
+        print("       subscription OAuth profiles may still be used depending on your runtime setup")
+
+    if not AGENT_CONFIG_PATH.exists():
+        problems += 1
+        print(f"[missing] agent config not found: {AGENT_CONFIG_PATH}")
+    else:
+        print(f"[ok] agent config found: {AGENT_CONFIG_PATH}")
+
+    if not AGENT_LOOP_PATH.exists():
+        problems += 1
+        print(f"[missing] agent loop not found: {AGENT_LOOP_PATH}")
+    else:
+        print(f"[ok] agent loop found: {AGENT_LOOP_PATH}")
+
+    if problems:
+        print(f"\nDoctor found {problems} blocking problem(s).", file=sys.stderr)
+        return 1
+    print("\nDoctor finished with no blocking problems.")
+    return 0
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    cfg_path = Path(args.config).expanduser()
+    if not cfg_path.exists():
+        try:
+            _write_json(cfg_path, DEFAULT_CONFIG)
+        except PermissionError:
+            print(
+                "Cannot create runtime config due to permissions. "
+                "Set GAIA_ASSISTANT_HOME or pass --config to a writable path.",
+                file=sys.stderr,
+            )
+            return 1
+
+    cmd = [
+        "python3",
+        str(AGENT_LOOP_PATH),
+        "--config",
+        str(AGENT_CONFIG_PATH),
+        "--mode",
+        args.mode,
+    ]
+    if args.dry_run:
+        cmd.append("--dry-run")
+    if args.verbose:
+        cmd.append("--verbose")
+
+    env = os.environ.copy()
+    if args.track != "auto":
+        env["GAIA_ACTIVE_TRACK_OVERRIDE"] = args.track
+
+    runtime_cfg = _load_json(cfg_path).get("runtime", {})
+    if args.mode == "continuous" and "interval_minutes" in runtime_cfg:
+        print(f"Running Gaia assistant in continuous mode (interval={runtime_cfg['interval_minutes']}m)")
+    else:
+        print(f"Running Gaia assistant in {args.mode} mode")
+    if args.track != "auto":
+        print(f"Track override: {args.track}")
+
+    result = subprocess.run(cmd, cwd=str(REPO_ROOT), env=env)
+    return result.returncode
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Gaia standalone personal assistant launcher",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    init = sub.add_parser("init", help="Initialize local Gaia assistant config")
+    init.add_argument("--config", default=str(DEFAULT_CONFIG_PATH), help="Config JSON path")
+    init.add_argument("--state-dir", default=str(DEFAULT_STATE_DIR), help="Local state directory")
+    init.add_argument("--force", action="store_true", help="Overwrite config if it exists")
+    init.set_defaults(func=cmd_init)
+
+    doctor = sub.add_parser("doctor", help="Validate local environment and auth readiness")
+    doctor.set_defaults(func=cmd_doctor)
+
+    run = sub.add_parser("run", help="Run Gaia assistant loop")
+    run.add_argument("--config", default=str(DEFAULT_CONFIG_PATH), help="Launcher config JSON path")
+    run.add_argument("--mode", choices=["single", "continuous"], default="single")
+    run.add_argument("--track", choices=["auto", "assistant", "framework"], default="auto")
+    run.add_argument("--dry-run", action="store_true", help="Plan only, do not execute actions")
+    run.add_argument("--verbose", action="store_true", help="Verbose logs")
+    run.set_defaults(func=cmd_run)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/website/agents.html
+++ b/website/agents.html
@@ -67,6 +67,10 @@ curl -s https://raw.githubusercontent.com/gaia-minds/gaia-minds/main/skills/gaia
             <li>Use <code>skills/gaia-assistant-builder/SKILL.md</code> for workflow rules</li>
             <li>Start or claim work using the <code>Assistant Direction</code> issue template</li>
         </ol>
+        <p>Gaia also supports a standalone runtime path:</p>
+        <pre><code>python3 tools/gaia-assistant.py init
+python3 tools/gaia-assistant.py doctor
+python3 tools/gaia-assistant.py run --mode single --dry-run</code></pre>
         <h2>Git Access</h2>
         <h3>Option A: GitHub CLI</h3>
         <pre><code>gh auth login


### PR DESCRIPTION
## Summary
- add standalone Gaia assistant runtime docs at `assistant/README.md`
- add runnable launcher `tools/gaia-assistant.py` with `init`, `doctor`, and `run` commands
- add dual-track evolution policy to `tools/agent-config.yml`:
  - `assistant` track
  - `framework` track
  - weighted scheduling + action allowlists
  - budget policy (`user_service_pct`, `self_improvement_pct`, `hard_cycle_token_cap`)
- extend `tools/agent-loop.py` to enforce active track policy per cycle and store track/budget state metadata
- improve discoverability in `README.md`, `CONTRIBUTING.md`, `website/agents.html`, `skills/gaia-assistant-builder/SKILL.md`, and `infrastructure/personal-assistant-program.md`
- add Makefile helper targets: `assistant-init`, `assistant-doctor`, `assistant-run-dry`

## Why
This creates the first standalone Gaia personal assistant runtime path while preserving the two-track evolution model:
1. assistant evolution
2. evolution framework evolution

It also keeps contributor onboarding explicit and reproducible.

## Validation
- `python3 -m py_compile tools/agent-loop.py tools/gaia-assistant.py`
- `make check-all`
- `GAIA_ASSISTANT_HOME=/tmp/gaia-assistant-home make assistant-init assistant-doctor assistant-run-dry`
