### PR TITLE
feat: add npm-first Gaia assistant CLI path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@ Thumbs.db
 .idea/
 .vscode/
 
+# Node
+node_modules/
+
 # Local assistant runtime state (never commit secrets/tokens)
 .gaia-assistant/

--- a/README.md
+++ b/README.md
@@ -49,13 +49,16 @@ If you want to contribute to the OpenClaw-powered assistant direction, start her
 Gaia now includes a standalone personal assistant launcher:
 
 1. Read [assistant/README.md](assistant/README.md)
-2. Run onboarding (includes web OAuth flow support):
-   `python3 tools/gaia-assistant.py onboard`
+2. Use the npm CLI wrapper (includes web OAuth flow support):
+   `npm install && npm run gaia -- onboard`
    default source is Gaia-native auth store + Codex CLI web/device login
 3. Check linked auth/profile status:
-   `python3 tools/gaia-assistant.py auth status && python3 tools/gaia-assistant.py doctor`
+   `npm run gaia -- auth status && npm run gaia -- doctor`
 4. Run a cycle:
-   `python3 tools/gaia-assistant.py run --mode single --dry-run`
+   `npm run gaia -- run --mode single --dry-run`
+
+Optional global CLI path from this repo clone:
+`npm install -g . && gaia doctor`
 
 OAuth security model:
 
@@ -76,8 +79,8 @@ Animated walkthrough:
 Try the same flow locally:
 
 ```bash
-python3 tools/gaia-assistant.py doctor
-GAIA_ASSISTANT_HOME=/tmp/gaia-assistant-home python3 tools/gaia-assistant.py run --mode single --dry-run
+npm run gaia -- doctor
+GAIA_ASSISTANT_HOME=/tmp/gaia-assistant-home npm run gaia -- run --mode single --dry-run
 ```
 
 ### Ways to Contribute
@@ -116,6 +119,9 @@ gaia-minds/
 ├── ROADMAP.md               # Priorities and milestones
 ├── CHANGELOG.md             # Project history
 ├── LICENSE                  # MIT License + disclaimer
+├── package.json             # npm CLI wrapper metadata
+├── bin/
+│   └── gaia.js              # npm `gaia` entrypoint -> Python runtime
 │
 ├── research/                # Collective knowledge
 │   ├── README.md

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -12,15 +12,20 @@ provider auth patterns:
 
 ```bash
 # From this repository
-python3 tools/gaia-assistant.py onboard
-python3 tools/gaia-assistant.py auth status
-python3 tools/gaia-assistant.py doctor
+npm install
+npm run gaia -- onboard
+npm run gaia -- auth status
+npm run gaia -- doctor
 
 # Single dry-run cycle
-python3 tools/gaia-assistant.py run --mode single --dry-run
+npm run gaia -- run --mode single --dry-run
 
 # Continuous assistant track
-python3 tools/gaia-assistant.py run --mode continuous --track assistant
+npm run gaia -- run --mode continuous --track assistant
+
+# Optional global command from this clone
+npm install -g .
+gaia doctor
 ```
 
 ## OAuth Onboarding
@@ -29,14 +34,14 @@ Gaia uses its own local auth store for ChatGPT/Codex-style profiles.
 The default OAuth broker is Codex CLI (web/device flow):
 
 ```bash
-python3 tools/gaia-assistant.py auth login --source codex-cli --provider openai-codex
-python3 tools/gaia-assistant.py auth status
+npm run gaia -- auth login --source codex-cli --provider openai-codex
+npm run gaia -- auth status
 ```
 
 If you already authenticated with Codex CLI, import/link without re-running login:
 
 ```bash
-python3 tools/gaia-assistant.py auth link --source codex-cli --provider openai-codex
+npm run gaia -- auth link --source codex-cli --provider openai-codex
 ```
 
 Optional compatibility path (legacy): link from OpenClaw profile store.
@@ -78,6 +83,10 @@ Expected environment variables for direct API mode:
 
 Provider OAuth profile support is exposed through Gaia-native commands:
 
+- `npm run gaia -- onboard`
+- `npm run gaia -- auth login --source codex-cli --provider openai-codex`
+
+Direct Python fallback (if preferred):
 - `python3 tools/gaia-assistant.py onboard`
 - `python3 tools/gaia-assistant.py auth login --source codex-cli --provider openai-codex`
 

--- a/bin/gaia.js
+++ b/bin/gaia.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const launcherPath = path.join(repoRoot, "tools", "gaia-assistant.py");
+
+if (!fs.existsSync(launcherPath)) {
+  console.error(`Gaia launcher not found at: ${launcherPath}`);
+  process.exit(1);
+}
+
+const passthroughArgs = process.argv.slice(2);
+const candidates = [];
+if (process.env.GAIA_PYTHON_BIN && process.env.GAIA_PYTHON_BIN.trim()) {
+  candidates.push({ cmd: process.env.GAIA_PYTHON_BIN.trim(), prefixArgs: [] });
+}
+candidates.push(
+  { cmd: "python3", prefixArgs: [] },
+  { cmd: "python", prefixArgs: [] },
+  { cmd: "py", prefixArgs: ["-3"] }
+);
+
+let lastError = null;
+for (const candidate of candidates) {
+  const result = spawnSync(
+    candidate.cmd,
+    [...candidate.prefixArgs, launcherPath, ...passthroughArgs],
+    {
+      cwd: repoRoot,
+      env: { ...process.env, GAIA_ASSISTANT_CLI_HINT: "gaia" },
+      stdio: "inherit",
+    }
+  );
+
+  if (result.error) {
+    if (result.error.code === "ENOENT") {
+      continue;
+    }
+    lastError = result.error;
+    break;
+  }
+
+  if (typeof result.status === "number") {
+    process.exit(result.status);
+  }
+
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+    process.exit(1);
+  }
+
+  process.exit(1);
+}
+
+if (lastError) {
+  console.error(`Failed to launch Gaia assistant: ${lastError.message}`);
+  process.exit(1);
+}
+
+console.error(
+  "Python 3 is required. Install Python or set GAIA_PYTHON_BIN to a valid interpreter."
+);
+process.exit(1);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@gaia-minds/assistant-cli",
+  "version": "0.1.0",
+  "private": true,
+  "description": "npm-first CLI wrapper for the Gaia standalone assistant runtime",
+  "license": "MIT",
+  "bin": {
+    "gaia": "./bin/gaia.js"
+  },
+  "scripts": {
+    "gaia": "node ./bin/gaia.js"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/tools/gaia-assistant.py
+++ b/tools/gaia-assistant.py
@@ -26,6 +26,7 @@ DEFAULT_STATE_DIR = DEFAULT_HOME / "state"
 DEFAULT_CONFIG_PATH = DEFAULT_HOME / "config.json"
 AGENT_CONFIG_PATH = SCRIPT_DIR / "agent-config.yml"
 AGENT_LOOP_PATH = SCRIPT_DIR / "agent-loop.py"
+DEFAULT_LAUNCHER_HINT = "python3 tools/gaia-assistant.py"
 DEFAULT_GAIA_AUTH_STORE = DEFAULT_HOME / "auth-profiles.json"
 DEFAULT_CODEX_AUTH_PATH = Path(
     os.environ.get("CODEX_HOME", str(Path.home() / ".codex"))
@@ -56,6 +57,11 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "default": "auto",
     },
 }
+
+
+def _launcher_hint() -> str:
+    hint = os.environ.get("GAIA_ASSISTANT_CLI_HINT", "").strip()
+    return hint if hint else DEFAULT_LAUNCHER_HINT
 
 
 def _load_json(path: Path) -> Dict[str, Any]:
@@ -450,13 +456,14 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     cfg = _load_json(cfg_path)
     if not cfg:
         print(f"[warn] launcher config not found yet: {cfg_path}")
-        print("       run `python3 tools/gaia-assistant.py init` or `... onboard`")
+        launcher = _launcher_hint()
+        print(f"       run `{launcher} init` or `{launcher} onboard`")
     else:
         cfg = _normalize_config(cfg)
         active = cfg.get("auth", {}).get("active_profile")
         if not isinstance(active, dict):
             print("[warn] no linked OAuth profile in launcher config")
-            print("       run `python3 tools/gaia-assistant.py onboard`")
+            print(f"       run `{_launcher_hint()} onboard`")
         else:
             credential, error = _read_linked_credential(active)
             if credential is None:
@@ -513,7 +520,7 @@ def cmd_onboard(args: argparse.Namespace) -> int:
         proceed = input("Start web OAuth login now? [Y/n]: ").strip().lower()
     if proceed in ("n", "no"):
         print("Skipped OAuth login. Run this later:")
-        print("  python3 tools/gaia-assistant.py auth login --provider openai-codex")
+        print(f"  {_launcher_hint()} auth login --provider openai-codex")
         return 0
 
     login_args = argparse.Namespace(
@@ -689,7 +696,7 @@ def cmd_auth_status(args: argparse.Namespace) -> int:
     active = cfg.get("auth", {}).get("active_profile")
     if not isinstance(active, dict):
         print("No linked auth profile in launcher config.")
-        print("Run: python3 tools/gaia-assistant.py auth login --provider openai-codex")
+        print(f"Run: {_launcher_hint()} auth login --provider openai-codex")
         return 1
 
     provider = str(active.get("provider", "")).strip()


### PR DESCRIPTION
## Summary
- add an npm CLI wrapper (`gaia`) that forwards to `tools/gaia-assistant.py`
- add `package.json` bin/script metadata so contributors can run `npm run gaia -- ...`
- update standalone runtime docs to use npm-first commands with Python fallback
- make launcher hints context-aware (`gaia ...`) when invoked through the npm wrapper

## Validation
- `python3 -m py_compile tools/gaia-assistant.py`
- `npm run gaia -- --help`
- `GAIA_ASSISTANT_HOME=/tmp/gaia-npm-test npm run gaia -- doctor`
- `make check-all`
