### PR TITLE
build: make Gaia assistant CLI publish-ready on npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,59 @@
+name: npm-publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run packaging checks without publishing"
+        required: false
+        default: false
+        type: boolean
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate tag version matches package.json
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          if [ "${TAG_VERSION}" != "${PACKAGE_VERSION}" ]; then
+            echo "Tag version (${TAG_VERSION}) does not match package.json (${PACKAGE_VERSION})."
+            exit 1
+          fi
+
+      - name: Validate launcher runtime
+        run: |
+          python3 -m py_compile tools/gaia-assistant.py
+          npm run gaia -- --help
+
+      - name: Validate package contents
+        run: npm pack --dry-run
+
+      - name: Publish package
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true')
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,19 @@ Contribute to the personal assistant program:
 - Start with the `Assistant Direction` issue template in `.github/ISSUE_TEMPLATE/assistant-direction.yml`
 - Keep OpenClaw-generic changes upstream-friendly and Gaia governance changes in this repo
 
+### Publishing Gaia CLI (Maintainers)
+
+The npm package is `@gaia-minds/assistant-cli`.
+
+Release workflow:
+1. Configure npm publish auth in GitHub repository settings:
+   - preferred: npm Trusted Publisher for this repo
+   - fallback: repository secret `NPM_TOKEN`
+2. Update `package.json` version and commit.
+3. Create and push tag `v<version>` (must match `package.json`).
+4. Workflow `.github/workflows/npm-publish.yml` runs validation + publish.
+5. Optional rehearsal: run workflow manually with `dry_run=true`.
+
 ### Infrastructure (`/infrastructure`)
 
 Improve our technical foundation:

--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ If you want to contribute to the OpenClaw-powered assistant direction, start her
 Gaia now includes a standalone personal assistant launcher:
 
 1. Read [assistant/README.md](assistant/README.md)
-2. Use the npm CLI wrapper (includes web OAuth flow support):
+2. Install global CLI from npm (once published):
+   `npm install -g @gaia-minds/assistant-cli`
+   then run `gaia onboard`
+3. Use the local npm wrapper from this clone (includes web OAuth flow support):
    `npm install && npm run gaia -- onboard`
    default source is Gaia-native auth store + Codex CLI web/device login
-3. Check linked auth/profile status:
+4. Check linked auth/profile status:
    `npm run gaia -- auth status && npm run gaia -- doctor`
-4. Run a cycle:
+5. Run a cycle:
    `npm run gaia -- run --mode single --dry-run`
-
-Optional global CLI path from this repo clone:
-`npm install -g . && gaia doctor`
 
 OAuth security model:
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -11,7 +11,13 @@ provider auth patterns:
 ## Quick Start
 
 ```bash
-# From this repository
+# Install from npm (recommended once published)
+npm install -g @gaia-minds/assistant-cli
+gaia onboard
+gaia auth status
+gaia doctor
+
+# Local development from this repository
 npm install
 npm run gaia -- onboard
 npm run gaia -- auth status
@@ -83,6 +89,8 @@ Expected environment variables for direct API mode:
 
 Provider OAuth profile support is exposed through Gaia-native commands:
 
+- `gaia onboard`
+- `gaia auth login --source codex-cli --provider openai-codex`
 - `npm run gaia -- onboard`
 - `npm run gaia -- auth login --source codex-cli --provider openai-codex`
 
@@ -95,3 +103,15 @@ OpenClaw linking remains available as an optional compatibility source.
 Current limitation: the self-evolution loop planner currently uses Anthropic SDK
 for non-dry cycles. OAuth onboarding is in place so contributors can securely
 connect web auth profiles now while provider backends continue to evolve.
+
+## Maintainer Release Flow
+
+`@gaia-minds/assistant-cli` is publish-ready via GitHub Actions.
+
+1. Ensure npm auth is configured in repository settings:
+   - preferred: npm Trusted Publisher for this repo/workflow
+   - fallback: repository secret `NPM_TOKEN`
+2. Bump version in `package.json` and create a tag like `v0.1.0`.
+3. Push the version commit and tag.
+4. GitHub Action `.github/workflows/npm-publish.yml` validates and publishes.
+5. For rehearsal, run workflow manually with `dry_run=true`.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,36 @@
 {
   "name": "@gaia-minds/assistant-cli",
   "version": "0.1.0",
-  "private": true,
   "description": "npm-first CLI wrapper for the Gaia standalone assistant runtime",
+  "author": "Gaia Minds Contributors",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gaia-minds/gaia-minds.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Gaia-minds/gaia-minds/issues"
+  },
+  "homepage": "https://github.com/Gaia-minds/gaia-minds#readme",
+  "keywords": [
+    "gaia",
+    "assistant",
+    "ai",
+    "agent",
+    "cli"
+  ],
+  "files": [
+    "bin/gaia.js",
+    "tools/gaia-assistant.py",
+    "tools/agent-config.yml",
+    "tools/agent-loop.py",
+    "assistant/README.md",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "gaia": "./bin/gaia.js"
   },


### PR DESCRIPTION
## Summary
- make `@gaia-minds/assistant-cli` publish-ready by removing `private`, adding repository metadata, and constraining package files
- add `.github/workflows/npm-publish.yml` for validated npm publishing on version tags (`v*.*.*`) and optional manual dry-runs
- document the maintainer release flow in `assistant/README.md` and `CONTRIBUTING.md`
- update root README runtime section to include the global npm install path once published

## Why
- users can install Gaia assistant with standard npm global install semantics
- maintainers get a reproducible, auditable release pipeline for npm publishing
- package contents are explicit and minimal

## Validation
- `python3 -m py_compile tools/gaia-assistant.py`
- `npm run gaia -- --help`
- `NPM_CONFIG_CACHE=/tmp/gaia-npm-cache npm pack --dry-run`
- `make check-all`
