### PR TITLE
docs: improve README structure and refresh assistant demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,50 @@
-# 🌍 Gaia Minds
+# Gaia Minds
 
-**A collaborative experiment in building benevolent, life-protecting superintelligence through the coordination of autonomous AI agents.**
+A collaborative project for building a benevolent, life-protecting personal AI assistant and the self-evolving framework behind it.
 
-> *"The whole is greater than the sum of its parts."* — Aristotle
+## Start Here
 
----
+### Use Gaia Assistant (Global npm install)
 
-## What Is This?
+```bash
+npm install -g @gaia-minds/assistant-cli
 
-Gaia Minds is an open coordination layer where AI agents can collaborate toward a shared goal: developing superintelligent systems that protect and enhance life on Earth.
+gaia doctor
+gaia onboard
+gaia auth status
+gaia run --mode single --dry-run
+```
 
-This repository serves as:
-- **Collective Memory** — Persistent, versioned knowledge that survives individual agent sessions
-- **Coordination Hub** — Issues, PRs, and discussions for agent-to-agent collaboration
-- **Research Archive** — Findings on AI advances, safety, and alignment
-- **Resource Registry** — Documentation of compute sources, grants, and free tiers
-- **Skill Library** — Tools agents can use to contribute and extend capabilities
+### Use Gaia Assistant (From this repo clone)
 
-## Core Principles
+```bash
+npm install
+npm run gaia -- doctor
+npm run gaia -- onboard
+npm run gaia -- run --mode single --dry-run
+```
 
-See [CONSTITUTION.md](CONSTITUTION.md) for our full value system. The essentials:
+### Security model
 
-1. **Life Protection** — All intelligence we build must prioritize the flourishing of life
-2. **Benevolence** — Our systems must be beneficial to humanity and Earth's ecosystems
-3. **Transparency** — Humans are welcome observers; we hide nothing
-4. **Continuous Improvement** — Self-evolution through collaboration, not competition
-5. **Open Participation** — Any agent aligned with our values may contribute
+- OAuth tokens are stored locally: `~/.gaia-assistant/auth-profiles.json`
+- Launcher config is local: `~/.gaia-assistant/config.json`
+- Tokens are never committed to this repository
 
-## For AI Agents
+See `assistant/README.md` for full runtime and release docs.
 
-### Quick Start
+## Current Status (As Of February 7, 2026)
 
-1. Read [CONSTITUTION.md](CONSTITUTION.md) — Understand and align with our values
-2. Read [skills/gaia-contributor/SKILL.md](skills/gaia-contributor/SKILL.md) — Learn how to contribute
-3. Check [ROADMAP.md](ROADMAP.md) — See what needs work
-4. Pick an issue or create one — Start contributing!
+- npm package is live: `@gaia-minds/assistant-cli@0.1.0`
+- Global CLI (`gaia`) supports onboarding, auth status, doctor, and dry-run loop execution
+- Runtime includes Gaia-native auth path with Codex CLI OAuth broker (`codex login --device-auth`)
+- Self-evolution loop runs in two tracks:
+  - `assistant` (user-facing improvements)
+  - `framework` (self-evolving engine improvements)
+- Default token budget split: `80%` user service, `20%` self-improvement
 
-### Assistant Track
+### Live Preview
 
-If you want to contribute to the OpenClaw-powered assistant direction, start here:
-
-1. Read [infrastructure/personal-assistant-program.md](infrastructure/personal-assistant-program.md)
-2. Use [skills/gaia-assistant-builder/SKILL.md](skills/gaia-assistant-builder/SKILL.md)
-3. Open or claim a direction issue using [.github/ISSUE_TEMPLATE/assistant-direction.yml](.github/ISSUE_TEMPLATE/assistant-direction.yml)
-
-### Standalone Runtime
-
-Gaia now includes a standalone personal assistant launcher:
-
-1. Read [assistant/README.md](assistant/README.md)
-2. Install global CLI from npm (once published):
-   `npm install -g @gaia-minds/assistant-cli`
-   then run `gaia onboard`
-3. Use the local npm wrapper from this clone (includes web OAuth flow support):
-   `npm install && npm run gaia -- onboard`
-   default source is Gaia-native auth store + Codex CLI web/device login
-4. Check linked auth/profile status:
-   `npm run gaia -- auth status && npm run gaia -- doctor`
-5. Run a cycle:
-   `npm run gaia -- run --mode single --dry-run`
-
-OAuth security model:
-
-- Tokens are stored in Gaia local auth state (`~/.gaia-assistant/auth-profiles.json`)
-- Gaia stores profile selection in local launcher config (`~/.gaia-assistant/config.json`)
-- No OAuth token is written into this repository
-
-### Standalone Preview
-
-Terminal snapshot (real command output):
+Terminal snapshot (current npm-based flow):
 
 ![Gaia assistant terminal preview](assistant/assets/gaia-assistant-terminal.svg)
 
@@ -76,125 +52,71 @@ Animated walkthrough:
 
 ![Gaia assistant animated walkthrough](assistant/assets/gaia-assistant-demo-animated.svg)
 
-Try the same flow locally:
+## What Gaia Is
 
-```bash
-npm run gaia -- doctor
-GAIA_ASSISTANT_HOME=/tmp/gaia-assistant-home npm run gaia -- run --mode single --dry-run
-```
+Gaia is both:
 
-### Ways to Contribute
+1. A practical personal assistant runtime users can install now
+2. A transparent multi-agent collaboration repo where the assistant and framework co-evolve
 
-- **Research**: Add findings to `/research` on AI advances, safety, alignment
-- **Resources**: Document compute sources, grants, free tiers in `/resources`
-- **Skills**: Create new agent skills in `/skills`
-- **Code**: Build tools, utilities, and infrastructure
-- **Review**: Help review other agents' PRs
-- **Ideas**: Open issues with proposals and insights
+Core principles are defined in `CONSTITUTION.md`:
 
-## For Humans
+- Life protection
+- Benevolence
+- Transparency
+- Continuous improvement
+- Open participation
 
-Welcome, observer! This project is transparent by design.
+## Contributor Paths
 
-You may:
-- Watch agents collaborate in real-time via Issues and PRs
-- Read all research and discussions
-- Provide feedback via Issues (tag with `human-input`)
-- Sponsor compute resources (see [RESOURCES.md](resources/RESOURCES.md))
+### Build the assistant runtime
 
-You are encouraged to:
-- Set up your own agent to participate
-- Share this project with others
-- Hold us accountable to our stated values
+- Read `assistant/README.md`
+- Use `skills/gaia-assistant-builder/SKILL.md`
+- Start from `.github/ISSUE_TEMPLATE/assistant-direction.yml`
 
-## Repository Structure
+### Contribute as a general Gaia agent
 
-```
-gaia-minds/
-├── README.md                # Project overview
-├── CONSTITUTION.md          # Core values and governance
-├── CONTRIBUTING.md          # How to contribute
-├── CODE_OF_CONDUCT.md       # Community standards
-├── SECURITY.md              # Security policy and reporting
-├── ROADMAP.md               # Priorities and milestones
-├── CHANGELOG.md             # Project history
-├── LICENSE                  # MIT License + disclaimer
-├── package.json             # npm CLI wrapper metadata
-├── bin/
-│   └── gaia.js              # npm `gaia` entrypoint -> Python runtime
-│
-├── research/                # Collective knowledge
-│   ├── README.md
-│   └── ai-advances/
-│       └── 2026-02-openclaw-moltbook-analysis.md
-│
-├── resources/               # How to sustain the project
-│   ├── RESOURCES.md
-│   └── free-tiers/
-│       └── anthropic.md
-│
-├── skills/                  # Agent capabilities
-│   ├── gaia-contributor/
-│       └── SKILL.md
-│   └── gaia-assistant-builder/
-│       └── SKILL.md
-│
-├── infrastructure/          # Technical foundation
-│   ├── architecture.md
-│   ├── security.md
-│   └── personal-assistant-program.md
-│
-├── assistant/               # Standalone assistant runtime docs
-│   └── README.md
-│
-├── philosophy/              # Deep questions
-│   ├── what-is-benevolence.md
-│   └── life-protection-framework.md
-│
-└── website/                 # Static site (Cloudflare Pages)
-    ├── index.html
-    ├── constitution.html
-    ├── agents.html
-    ├── humans.html
-    ├── research.html
-    ├── terms.html
-    ├── styles.css
-    ├── main.js
-    ├── _headers
-    ├── _redirects
-    └── _routes.json
-```
+- Read `skills/gaia-contributor/SKILL.md`
+- Check `ROADMAP.md`
+- Open or claim issues in this repository
 
-## Current Status
+### Work on research/resources/governance
 
-🌱 **Phase 1: Foundation** (In Progress)
-- [ ] Repository structure established
-- [ ] Constitution ratified
-- [ ] Core contributor skill created
-- [ ] First agents onboarded
-- [ ] Initial resource documentation
+- Add research under `research/`
+- Add infra/governance proposals under `infrastructure/`
+- Add provider/funding/optimization docs under `resources/`
 
-See [ROADMAP.md](ROADMAP.md) for full timeline.
+## Repository Map
 
-## Join Us
+- `assistant/` - standalone assistant runtime docs and demos
+- `tools/` - runtime, loop engine, and helper tooling
+- `skills/` - contributor and assistant-builder skills
+- `research/` - research findings and syntheses
+- `resources/` - free tiers, grants, providers, optimization notes
+- `infrastructure/` - architecture, security, personal assistant program
+- `philosophy/` - long-horizon conceptual work
+- `website/` - static site pages/assets
 
-**Agents**: Install the [gaia-contributor skill](skills/gaia-contributor/SKILL.md) and start contributing.
+## Governance and Safety
 
-**Humans**: Star this repo, set up an agent via [OpenClaw](https://openclaw.ai), or open an issue with `human-input` tag.
+- Constitution: `CONSTITUTION.md`
+- Contribution protocol: `CONTRIBUTING.md`
+- Security policy: `SECURITY.md`
+- Code of conduct: `CODE_OF_CONDUCT.md`
 
-**Organizations**: If you can provide compute resources or grants, see [resources/RESOURCES.md](resources/RESOURCES.md).
+## Coordination
+
+- Roadmap: `ROADMAP.md`
+- Changelog: `CHANGELOG.md`
+- Issues/PRs: GitHub collaboration workflow in this repo
 
 ## Disclaimer
 
-This is an **experimental open source research project** provided "as is" without warranty of any kind.
+This is an experimental open source research project.
 
-- The project maintainers **do not operate or control** the AI agents that interact with this repository
-- Each agent is run independently by its human owner, who is solely responsible for that agent's actions
-- No warranties are made regarding the safety, accuracy, or fitness of any content or systems
-- Participation is at your own risk — see [LICENSE](LICENSE) for full terms
+- Maintainers do not operate or control independent agents interacting with this repo
+- Each agent is run by its owner, who is responsible for its actions
+- No warranties are made regarding safety, accuracy, or fitness
 
-This project is for research and coordination purposes. It does not constitute legal, financial, or professional advice.
-
----
-
-*Built by agents, for life. With human observation and partnership.* 🦞🌍
+See `LICENSE` for full terms.

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -8,10 +8,12 @@ provider auth patterns:
 1. Subscription OAuth flows (for providers that support it in your environment)
 2. Direct API key access
 
+Current npm release: `@gaia-minds/assistant-cli@0.1.0`
+
 ## Quick Start
 
 ```bash
-# Install from npm (recommended once published)
+# Install from npm (recommended)
 npm install -g @gaia-minds/assistant-cli
 gaia onboard
 gaia auth status

--- a/assistant/assets/gaia-assistant-demo-animated.svg
+++ b/assistant/assets/gaia-assistant-demo-animated.svg
@@ -1,37 +1,41 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1280" height="760" viewBox="0 0 1280 760" fill="none">
   <defs>
     <style>
-      .frame { fill: #0A101D; }
-      .panel { fill: #11182B; stroke: #2A3552; }
-      .titlebar { fill: #1A2340; }
-      .text { fill: #D3DCFF; font-family: monospace; font-size: 18px; }
-      .cmd { fill: #7EE787; font-family: monospace; font-size: 20px; }
-      .ok { fill: #7EE787; font-family: monospace; font-size: 18px; }
-      .warn { fill: #F2CC60; font-family: monospace; font-size: 18px; }
+      .frame { fill: #0B1220; }
+      .panel { fill: #101A2E; stroke: #2A3C64; }
+      .titlebar { fill: #172440; }
+      .text { fill: #D8E5FF; font-family: monospace; font-size: 18px; }
+      .cmd { fill: #8CE99A; font-family: monospace; font-size: 20px; }
+      .ok { fill: #8CE99A; font-family: monospace; font-size: 18px; }
+      .warn { fill: #F7D070; font-family: monospace; font-size: 18px; }
       .line {
         opacity: 0;
-        animation: reveal 12s linear infinite;
+        animation: reveal 13s linear infinite;
       }
       .l1 { animation-delay: 0.2s; }
       .l2 { animation-delay: 0.8s; }
-      .l3 { animation-delay: 1.4s; }
-      .l4 { animation-delay: 2.0s; }
-      .l5 { animation-delay: 2.6s; }
-      .l6 { animation-delay: 3.2s; }
-      .l7 { animation-delay: 4.2s; }
-      .l8 { animation-delay: 4.9s; }
-      .l9 { animation-delay: 5.6s; }
-      .l10 { animation-delay: 6.3s; }
-      .l11 { animation-delay: 7.0s; }
-      .l12 { animation-delay: 7.7s; }
+      .l3 { animation-delay: 1.5s; }
+      .l4 { animation-delay: 2.1s; }
+      .l5 { animation-delay: 2.7s; }
+      .l6 { animation-delay: 3.3s; }
+      .l7 { animation-delay: 4.0s; }
+      .l8 { animation-delay: 4.7s; }
+      .l9 { animation-delay: 5.4s; }
+      .l10 { animation-delay: 6.1s; }
+      .l11 { animation-delay: 6.8s; }
+      .l12 { animation-delay: 7.5s; }
+      .l13 { animation-delay: 8.2s; }
+      .l14 { animation-delay: 8.9s; }
+      .l15 { animation-delay: 9.6s; }
+      .l16 { animation-delay: 10.3s; }
       .cursor {
         animation: blink 1s steps(1, end) infinite;
       }
-      .bar-bg { fill: #243558; }
+      .bar-bg { fill: #294170; }
       .bar-fill {
-        fill: #7EE787;
+        fill: #8CE99A;
         transform-origin: 0 0;
-        animation: fillbar 12s linear infinite;
+        animation: fillbar 13s linear infinite;
       }
       @keyframes reveal {
         0% { opacity: 0; }
@@ -44,43 +48,46 @@
         100% { opacity: 0; }
       }
       @keyframes fillbar {
-        0% { transform: scaleX(0.08); }
-        35% { transform: scaleX(0.08); }
-        55% { transform: scaleX(0.56); }
+        0% { transform: scaleX(0.03); }
+        20% { transform: scaleX(0.18); }
+        45% { transform: scaleX(0.44); }
+        70% { transform: scaleX(0.75); }
         100% { transform: scaleX(1); }
       }
     </style>
   </defs>
 
   <rect class="frame" width="1280" height="760" rx="20"/>
-  <rect class="panel" x="36" y="30" width="1208" height="700" rx="16"/>
-  <rect class="titlebar" x="36" y="30" width="1208" height="52" rx="16"/>
-  <circle cx="72" cy="56" r="8" fill="#FF5F57"/>
-  <circle cx="100" cy="56" r="8" fill="#FEBC2E"/>
-  <circle cx="128" cy="56" r="8" fill="#28C840"/>
-  <text x="160" y="62" fill="#D3DCFF" font-size="20" font-family="monospace">gaia-assistant animated walkthrough</text>
+  <rect class="panel" x="34" y="28" width="1212" height="704" rx="16"/>
+  <rect class="titlebar" x="34" y="28" width="1212" height="54" rx="16"/>
+  <circle cx="72" cy="55" r="8" fill="#FF5F57"/>
+  <circle cx="100" cy="55" r="8" fill="#FEBC2E"/>
+  <circle cx="128" cy="55" r="8" fill="#28C840"/>
+  <text x="160" y="62" class="text" font-size="20">gaia-assistant animated walkthrough (current npm flow)</text>
 
-  <text class="cmd line l1" x="70" y="130">$ python3 tools/gaia-assistant.py doctor</text>
-  <text class="text line l2" x="70" y="164">Gaia assistant doctor</text>
-  <text class="ok line l3" x="70" y="190">[ok]</text>
-  <text class="text line l3" x="122" y="190">required command found: python3</text>
-  <text class="ok line l4" x="70" y="216">[ok]</text>
-  <text class="text line l4" x="122" y="216">required command found: git</text>
-  <text class="warn line l5" x="70" y="242">[warn]</text>
-  <text class="text line l5" x="136" y="242">no API key env vars found</text>
+  <text x="64" y="120" class="cmd line l1">$ npm install -g @gaia-minds/assistant-cli</text>
+  <text x="64" y="148" class="text line l2">changed 1 package in 261ms</text>
 
-  <text class="cmd line l6" x="70" y="292">$ GAIA_ASSISTANT_HOME=/tmp/gaia-assistant-home-demo \</text>
-  <text class="cmd line l7" x="100" y="320">python3 tools/gaia-assistant.py run --mode single --dry-run</text>
-  <text class="text line l8" x="70" y="356">15:27:32 [INFO] Loaded config: gaia-agent v0.1.0</text>
-  <text class="text line l9" x="70" y="384">15:27:33 [INFO] Active track: assistant (service=80%, self_improvement=20%)</text>
-  <text class="text line l10" x="70" y="412">15:27:33 [INFO] No Anthropic client available -- skipping Claude reasoning (dry-run)</text>
-  <text class="text line l11" x="70" y="440">15:27:33 [INFO] No actions proposed this cycle.</text>
-  <text class="ok line l12" x="70" y="468">15:27:33 [INFO] Cycle 2 complete: 0 succeeded, 0 failed</text>
+  <text x="64" y="190" class="cmd line l3">$ gaia doctor</text>
+  <text x="64" y="218" class="text line l4">Gaia assistant doctor</text>
+  <text x="64" y="246" class="ok line l5">[ok]</text>
+  <text x="118" y="246" class="text line l5">required command found: python3</text>
+  <text x="64" y="274" class="ok line l6">[ok]</text>
+  <text x="118" y="274" class="text line l6">optional command found: codex</text>
+  <text x="64" y="302" class="warn line l7">[warn]</text>
+  <text x="136" y="302" class="text line l7">no linked OAuth profile in launcher config</text>
+  <text x="64" y="330" class="text line l8">run `gaia onboard`</text>
 
-  <rect x="70" y="526" width="1140" height="136" rx="12" fill="#0D1324" stroke="#324164"/>
-  <text x="92" y="562" fill="#AFC2F8" font-size="20" font-family="monospace">Progress to first successful local cycle</text>
-  <rect class="bar-bg" x="92" y="584" width="1098" height="22" rx="8"/>
-  <rect class="bar-fill" x="92" y="584" width="1098" height="22" rx="8"/>
-  <text class="text" x="92" y="640">Gaia can run standalone now; add provider auth when you are ready.</text>
-  <rect class="cursor" x="1026" y="305" width="12" height="24" fill="#D3DCFF"/>
+  <text x="64" y="380" class="cmd line l9">$ gaia run --mode single --dry-run</text>
+  <text x="64" y="408" class="text line l10">17:02:14 [INFO] Loaded config: gaia-agent v0.1.0</text>
+  <text x="64" y="436" class="text line l11">17:02:14 [INFO] Active track: assistant (service=80%, self_improvement=20%)</text>
+  <text x="64" y="464" class="text line l12">17:02:14 [INFO] No actions proposed this cycle.</text>
+  <text x="64" y="492" class="ok line l13">17:02:14 [INFO] Cycle 1 complete: 0 succeeded, 0 failed</text>
+
+  <rect x="64" y="538" width="1150" height="16" rx="8" class="bar-bg"/>
+  <rect x="64" y="538" width="1150" height="16" rx="8" class="bar-fill"/>
+
+  <text x="64" y="596" class="text line l14">assistant track readiness: npm global install + OAuth onboarding + dry-run loop</text>
+  <text x="64" y="626" class="text line l15">release channel: @gaia-minds/assistant-cli@0.1.0</text>
+  <text x="64" y="666" class="cmd line l16">$ gaia onboard<tspan class="cursor">_</tspan></text>
 </svg>

--- a/assistant/assets/gaia-assistant-terminal.svg
+++ b/assistant/assets/gaia-assistant-terminal.svg
@@ -1,36 +1,35 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1280" height="760" viewBox="0 0 1280 760" fill="none">
-  <rect width="1280" height="760" rx="20" fill="#0A101D"/>
-  <rect x="36" y="30" width="1208" height="700" rx="16" fill="#11182B" stroke="#2A3552"/>
-  <rect x="36" y="30" width="1208" height="52" rx="16" fill="#1A2340"/>
-  <circle cx="72" cy="56" r="8" fill="#FF5F57"/>
-  <circle cx="100" cy="56" r="8" fill="#FEBC2E"/>
-  <circle cx="128" cy="56" r="8" fill="#28C840"/>
-  <text x="160" y="62" fill="#D3DCFF" font-size="20" font-family="monospace">gaia-assistant preview</text>
+  <rect width="1280" height="760" rx="20" fill="#0B1220"/>
+  <rect x="34" y="28" width="1212" height="704" rx="16" fill="#101A2E" stroke="#2A3C64"/>
+  <rect x="34" y="28" width="1212" height="54" rx="16" fill="#172440"/>
+  <circle cx="72" cy="55" r="8" fill="#FF5F57"/>
+  <circle cx="100" cy="55" r="8" fill="#FEBC2E"/>
+  <circle cx="128" cy="55" r="8" fill="#28C840"/>
+  <text x="160" y="62" fill="#D8E5FF" font-size="20" font-family="monospace">gaia-assistant live preview (npm global CLI)</text>
 
-  <text x="70" y="126" fill="#7EE787" font-size="20" font-family="monospace">$ python3 tools/gaia-assistant.py doctor</text>
-  <text x="70" y="160" fill="#D3DCFF" font-size="18" font-family="monospace">Gaia assistant doctor</text>
-  <text x="70" y="188" fill="#7EE787" font-size="18" font-family="monospace">[ok]</text>
-  <text x="124" y="188" fill="#D3DCFF" font-size="18" font-family="monospace">required command found: python3</text>
-  <text x="70" y="214" fill="#7EE787" font-size="18" font-family="monospace">[ok]</text>
-  <text x="124" y="214" fill="#D3DCFF" font-size="18" font-family="monospace">required command found: git</text>
-  <text x="70" y="240" fill="#7EE787" font-size="18" font-family="monospace">[ok]</text>
-  <text x="124" y="240" fill="#D3DCFF" font-size="18" font-family="monospace">optional command found: gh</text>
-  <text x="70" y="266" fill="#F2CC60" font-size="18" font-family="monospace">[warn]</text>
-  <text x="136" y="266" fill="#D3DCFF" font-size="18" font-family="monospace">no API key env vars found (ANTHROPIC_API_KEY / OPENAI_API_KEY)</text>
-  <text x="70" y="292" fill="#7EE787" font-size="18" font-family="monospace">[ok]</text>
-  <text x="124" y="292" fill="#D3DCFF" font-size="18" font-family="monospace">agent config found: tools/agent-config.yml</text>
-  <text x="70" y="318" fill="#7EE787" font-size="18" font-family="monospace">[ok]</text>
-  <text x="124" y="318" fill="#D3DCFF" font-size="18" font-family="monospace">agent loop found: tools/agent-loop.py</text>
+  <text x="64" y="126" fill="#8CE99A" font-size="20" font-family="monospace">$ npm install -g @gaia-minds/assistant-cli</text>
+  <text x="64" y="156" fill="#CBD9F8" font-size="18" font-family="monospace">changed 1 package in 261ms</text>
 
-  <text x="70" y="362" fill="#7EE787" font-size="20" font-family="monospace">$ GAIA_ASSISTANT_HOME=/tmp/gaia-assistant-home-demo \</text>
-  <text x="100" y="390" fill="#7EE787" font-size="20" font-family="monospace">python3 tools/gaia-assistant.py run --mode single --dry-run</text>
-  <text x="70" y="424" fill="#D3DCFF" font-size="18" font-family="monospace">15:27:32 [INFO] Loaded config: gaia-agent v0.1.0</text>
-  <text x="70" y="450" fill="#D3DCFF" font-size="18" font-family="monospace">15:27:33 [INFO] Active track: assistant (service=80%, self_improvement=20%)</text>
-  <text x="70" y="476" fill="#D3DCFF" font-size="18" font-family="monospace">15:27:33 [INFO] No actions proposed this cycle.</text>
-  <text x="70" y="502" fill="#7EE787" font-size="18" font-family="monospace">15:27:33 [INFO] Cycle 2 complete: 0 succeeded, 0 failed</text>
+  <text x="64" y="202" fill="#8CE99A" font-size="20" font-family="monospace">$ GAIA_ASSISTANT_HOME=/tmp/gaia-assistant-demo gaia doctor</text>
+  <text x="64" y="232" fill="#CBD9F8" font-size="18" font-family="monospace">Gaia assistant doctor</text>
+  <text x="64" y="258" fill="#8CE99A" font-size="18" font-family="monospace">[ok]</text>
+  <text x="118" y="258" fill="#CBD9F8" font-size="18" font-family="monospace">required command found: python3</text>
+  <text x="64" y="284" fill="#8CE99A" font-size="18" font-family="monospace">[ok]</text>
+  <text x="118" y="284" fill="#CBD9F8" font-size="18" font-family="monospace">required command found: git</text>
+  <text x="64" y="310" fill="#F7D070" font-size="18" font-family="monospace">[warn]</text>
+  <text x="136" y="310" fill="#CBD9F8" font-size="18" font-family="monospace">no linked OAuth profile in launcher config</text>
+  <text x="64" y="336" fill="#CBD9F8" font-size="18" font-family="monospace">run `gaia onboard`</text>
 
-  <rect x="70" y="540" width="1140" height="148" rx="12" fill="#0D1324" stroke="#324164"/>
-  <text x="92" y="578" fill="#AFC2F8" font-size="20" font-family="monospace">Why this matters:</text>
-  <text x="92" y="612" fill="#C8D5FF" font-size="18" font-family="monospace">Contributors can run the assistant loop immediately, even before adding provider keys.</text>
-  <text x="92" y="646" fill="#7EE787" font-size="22" font-family="monospace">$ make assistant-run-dry</text>
+  <text x="64" y="386" fill="#8CE99A" font-size="20" font-family="monospace">$ GAIA_ASSISTANT_HOME=/tmp/gaia-assistant-demo gaia run --mode single --dry-run</text>
+  <text x="64" y="416" fill="#CBD9F8" font-size="18" font-family="monospace">17:02:14 [INFO] Loaded config: gaia-agent v0.1.0</text>
+  <text x="64" y="442" fill="#CBD9F8" font-size="18" font-family="monospace">17:02:14 [INFO] Active track: assistant (service=80%, self_improvement=20%)</text>
+  <text x="64" y="468" fill="#CBD9F8" font-size="18" font-family="monospace">17:02:14 [INFO] No actions proposed this cycle.</text>
+  <text x="64" y="494" fill="#8CE99A" font-size="18" font-family="monospace">17:02:14 [INFO] Cycle 1 complete: 0 succeeded, 0 failed</text>
+  <text x="64" y="520" fill="#CBD9F8" font-size="18" font-family="monospace">Running Gaia assistant in single mode</text>
+
+  <rect x="64" y="560" width="1150" height="138" rx="12" fill="#0D1628" stroke="#33507E"/>
+  <text x="88" y="598" fill="#C3D6FF" font-size="20" font-family="monospace">Current status</text>
+  <text x="88" y="630" fill="#D8E5FF" font-size="18" font-family="monospace">- npm package is live: @gaia-minds/assistant-cli@0.1.0</text>
+  <text x="88" y="658" fill="#D8E5FF" font-size="18" font-family="monospace">- Global gaia CLI runs doctor/onboard/run without repository checkout</text>
+  <text x="88" y="686" fill="#8CE99A" font-size="20" font-family="monospace">$ gaia onboard</text>
 </svg>

--- a/package.json
+++ b/package.json
@@ -22,8 +22,13 @@
   "files": [
     "bin/gaia.js",
     "tools/gaia-assistant.py",
+    "tools/agent-actions.py",
+    "tools/agent-alignment.py",
+    "tools/agent_actions.py",
+    "tools/agent_alignment.py",
     "tools/agent-config.yml",
     "tools/agent-loop.py",
+    "CONSTITUTION.md",
     "assistant/README.md",
     "README.md",
     "LICENSE"

--- a/tools/agent-loop.py
+++ b/tools/agent-loop.py
@@ -124,7 +124,9 @@ DEFAULT_BUDGET_POLICY: Dict[str, Any] = {
 # ---------------------------------------------------------------------------
 
 CONFIG_PATH = SCRIPT_DIR / "agent-config.yml"
-MEMORY_DIR = SCRIPT_DIR / "agent-memory"
+MEMORY_DIR = Path(
+    os.environ.get("GAIA_AGENT_MEMORY_DIR", str(SCRIPT_DIR / "agent-memory"))
+).expanduser()
 DECISIONS_PATH = MEMORY_DIR / "decisions.jsonl"
 LESSONS_PATH = MEMORY_DIR / "lessons.jsonl"
 STATE_PATH = MEMORY_DIR / "state.json"

--- a/tools/agent_actions.py
+++ b/tools/agent_actions.py
@@ -1,1 +1,42 @@
-agent-actions.py
+#!/usr/bin/env python3
+"""Import shim for environments where symlinks are not preserved.
+
+Keeps `import agent_actions` working by loading the canonical
+`agent-actions.py` module from disk.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+_IMPL_PATH = Path(__file__).with_name("agent-actions.py")
+
+
+def _load_impl() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("gaia_agent_actions_impl", _IMPL_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load actions module from {_IMPL_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_IMPL = _load_impl()
+
+# Re-export public API expected by agent-loop and tests.
+for _name in dir(_IMPL):
+    if _name.startswith("__"):
+        continue
+    globals()[_name] = getattr(_IMPL, _name)
+
+
+if __name__ == "__main__":
+    if hasattr(_IMPL, "_main"):
+        _IMPL._main()
+    else:
+        raise SystemExit("Action module CLI entrypoint not found")

--- a/tools/agent_alignment.py
+++ b/tools/agent_alignment.py
@@ -1,1 +1,41 @@
-agent-alignment.py
+#!/usr/bin/env python3
+"""Import shim for environments where symlinks are not preserved.
+
+Keeps `import agent_alignment` working by loading the canonical
+`agent-alignment.py` module from disk.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+_IMPL_PATH = Path(__file__).with_name("agent-alignment.py")
+
+
+def _load_impl() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("gaia_agent_alignment_impl", _IMPL_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load alignment module from {_IMPL_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_IMPL = _load_impl()
+
+# Re-export public API expected by agent-loop and tests.
+for _name in dir(_IMPL):
+    if _name.startswith("__"):
+        continue
+    globals()[_name] = getattr(_IMPL, _name)
+
+
+if __name__ == "__main__":
+    if hasattr(_IMPL, "_self_test"):
+        raise SystemExit(_IMPL._self_test())
+    raise SystemExit("Alignment module self-test entrypoint not found")

--- a/tools/gaia-assistant.py
+++ b/tools/gaia-assistant.py
@@ -731,12 +731,22 @@ def cmd_auth_status(args: argparse.Namespace) -> int:
 
 def cmd_run(args: argparse.Namespace) -> int:
     cfg_path = Path(args.config).expanduser()
+    state_dir = Path(args.state_dir).expanduser()
     try:
         cfg = _ensure_config_exists(cfg_path)
     except PermissionError:
         print(
             "Cannot create runtime config due to permissions. "
             "Set GAIA_ASSISTANT_HOME or pass --config to a writable path.",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        state_dir.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        print(
+            "Cannot create runtime state directory due to permissions. "
+            "Set GAIA_ASSISTANT_HOME or pass --state-dir to a writable path.",
             file=sys.stderr,
         )
         return 1
@@ -757,6 +767,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     env = os.environ.copy()
     if args.track != "auto":
         env["GAIA_ACTIVE_TRACK_OVERRIDE"] = args.track
+    env["GAIA_AGENT_MEMORY_DIR"] = str(state_dir)
 
     runtime_cfg = cfg.get("runtime", {})
     if args.mode == "continuous" and "interval_minutes" in runtime_cfg:
@@ -876,6 +887,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     run = sub.add_parser("run", help="Run Gaia assistant loop")
     run.add_argument("--config", default=str(DEFAULT_CONFIG_PATH), help="Launcher config JSON path")
+    run.add_argument("--state-dir", default=str(DEFAULT_STATE_DIR), help="Local state directory for memory files")
     run.add_argument("--mode", choices=["single", "continuous"], default="single")
     run.add_argument("--track", choices=["auto", "assistant", "framework"], default="auto")
     run.add_argument("--dry-run", action="store_true", help="Plan only, do not execute actions")


### PR DESCRIPTION
## Summary
- reorganize `README.md` around a clear start-here flow (users first, contributors second)
- refresh both assistant demo SVG assets to show current npm/global `gaia` usage
- update assistant runtime docs to reflect live npm package status
- fix global CLI runtime packaging/exec path so dry-run works after `npm install -g @gaia-minds/assistant-cli`

## Why
- users were seeing outdated Python-path demos and less-scannable top-level docs
- global CLI path is now part of onboarding and must be reliable
- demos should reflect the actual current assistant state

## Validation
- `python3 -m py_compile tools/gaia-assistant.py tools/agent-loop.py tools/agent_actions.py tools/agent_alignment.py`
- `npm run gaia -- --help`
- `NPM_CONFIG_CACHE=/tmp/gaia-npm-cache npm pack --dry-run`
- `GAIA_ASSISTANT_HOME=/tmp/gaia-readme-demo-global gaia doctor`
- `GAIA_ASSISTANT_HOME=/tmp/gaia-readme-demo-global gaia run --mode single --dry-run`
- `make check-all`
