### PR TITLE
build: release Gaia assistant CLI 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See `assistant/README.md` for full runtime and release docs.
 
 ## Current Status (As Of February 7, 2026)
 
-- npm package is live: `@gaia-minds/assistant-cli@0.1.0`
+- npm package is live: `@gaia-minds/assistant-cli@0.1.1`
 - Global CLI (`gaia`) supports onboarding, auth status, doctor, and dry-run loop execution
 - Runtime includes Gaia-native auth path with Codex CLI OAuth broker (`codex login --device-auth`)
 - Self-evolution loop runs in two tracks:

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -8,7 +8,7 @@ provider auth patterns:
 1. Subscription OAuth flows (for providers that support it in your environment)
 2. Direct API key access
 
-Current npm release: `@gaia-minds/assistant-cli@0.1.0`
+Current npm release: `@gaia-minds/assistant-cli@0.1.1`
 
 ## Quick Start
 
@@ -113,7 +113,7 @@ connect web auth profiles now while provider backends continue to evolve.
 1. Ensure npm auth is configured in repository settings:
    - preferred: npm Trusted Publisher for this repo/workflow
    - fallback: repository secret `NPM_TOKEN`
-2. Bump version in `package.json` and create a tag like `v0.1.0`.
+2. Bump version in `package.json` and create a tag like `v0.1.1`.
 3. Push the version commit and tag.
 4. GitHub Action `.github/workflows/npm-publish.yml` validates and publishes.
 5. For rehearsal, run workflow manually with `dry_run=true`.

--- a/assistant/assets/gaia-assistant-demo-animated.svg
+++ b/assistant/assets/gaia-assistant-demo-animated.svg
@@ -88,6 +88,6 @@
   <rect x="64" y="538" width="1150" height="16" rx="8" class="bar-fill"/>
 
   <text x="64" y="596" class="text line l14">assistant track readiness: npm global install + OAuth onboarding + dry-run loop</text>
-  <text x="64" y="626" class="text line l15">release channel: @gaia-minds/assistant-cli@0.1.0</text>
+  <text x="64" y="626" class="text line l15">release channel: @gaia-minds/assistant-cli@0.1.1</text>
   <text x="64" y="666" class="cmd line l16">$ gaia onboard<tspan class="cursor">_</tspan></text>
 </svg>

--- a/assistant/assets/gaia-assistant-terminal.svg
+++ b/assistant/assets/gaia-assistant-terminal.svg
@@ -29,7 +29,7 @@
 
   <rect x="64" y="560" width="1150" height="138" rx="12" fill="#0D1628" stroke="#33507E"/>
   <text x="88" y="598" fill="#C3D6FF" font-size="20" font-family="monospace">Current status</text>
-  <text x="88" y="630" fill="#D8E5FF" font-size="18" font-family="monospace">- npm package is live: @gaia-minds/assistant-cli@0.1.0</text>
+  <text x="88" y="630" fill="#D8E5FF" font-size="18" font-family="monospace">- npm package is live: @gaia-minds/assistant-cli@0.1.1</text>
   <text x="88" y="658" fill="#D8E5FF" font-size="18" font-family="monospace">- Global gaia CLI runs doctor/onboard/run without repository checkout</text>
   <text x="88" y="686" fill="#8CE99A" font-size="20" font-family="monospace">$ gaia onboard</text>
 </svg>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-minds/assistant-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "npm-first CLI wrapper for the Gaia standalone assistant runtime",
   "author": "Gaia Minds Contributors",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump npm package version from `0.1.0` to `0.1.1`
- update README/assistant docs/demo text to reference the live release version `0.1.1`

## Why
The previous PR fixed global runtime behavior on `main`; this release PR publishes those fixes so `npm install -g @gaia-minds/assistant-cli` matches current docs and demo output.

## Validation
- `npm run gaia -- --help`
- `npm pack --dry-run`
- `make check-all`
