### PR TITLE
feat: add phase 1 benchmark harness and baseline artifacts

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,32 @@
+name: benchmark
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run benchmark suite
+        run: make benchmark
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: assistant/benchmark-results.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs-check verify-resources generate-indexes check-indexes check-all test-smoke hardening-phase1 install-hooks uninstall-hooks assistant-init assistant-onboard assistant-auth-status assistant-doctor assistant-run-dry
+.PHONY: docs-check verify-resources generate-indexes check-indexes check-all test-smoke benchmark hardening-phase1 install-hooks uninstall-hooks assistant-init assistant-onboard assistant-auth-status assistant-doctor assistant-run-dry
 
 docs-check:
 	./tools/validate-docs.sh
@@ -18,6 +18,9 @@ check-all: docs-check check-indexes
 
 test-smoke:
 	./tools/smoke-test.sh --json-out smoke-results.json
+
+benchmark:
+	python3 ./tools/benchmark.py
 
 hardening-phase1:
 	python3 ./tools/phase1-hardening.py

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -28,6 +28,9 @@ npm run gaia -- doctor
 # Single dry-run cycle
 npm run gaia -- run --mode single --dry-run
 
+# Deterministic benchmark run
+make benchmark
+
 # Continuous assistant track
 npm run gaia -- run --mode continuous --track assistant
 
@@ -130,6 +133,17 @@ Capability policy can be reviewed and overridden locally:
 gaia capability list
 gaia capability set send_email confirm
 ```
+
+## Benchmarking
+
+Benchmark the 20 canonical Phase 1 tasks:
+
+```bash
+make benchmark
+```
+
+- Methodology and update process: `assistant/benchmarking.md`
+- Baseline artifact: `assistant/benchmark-baseline.json`
 
 ## Budget Policy
 

--- a/assistant/benchmark-baseline.json
+++ b/assistant/benchmark-baseline.json
@@ -1,0 +1,156 @@
+{
+  "failed": 0,
+  "methodology": {
+    "description": "Phase 1 canonical task pass/fail benchmark",
+    "runner": "tools/phase1-hardening.py",
+    "task_source": "assistant/canonical-tasks.md"
+  },
+  "passed": 20,
+  "schema_version": 1,
+  "score_pct": 100.0,
+  "suite": "phase1-canonical-benchmark",
+  "target_score_pct": 80.0,
+  "tasks": [
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'profile.name=HardeningUser'",
+      "id": "T01",
+      "passed": true,
+      "title": "Config set name"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'HardeningUser'",
+      "id": "T02",
+      "passed": true,
+      "title": "Config get name"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'profile.verbosity=concise'",
+      "id": "T03",
+      "passed": true,
+      "title": "Config set verbosity"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'profile.default_provider=openai'",
+      "id": "T04",
+      "passed": true,
+      "title": "Config set provider"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'send_email forbidden'",
+      "id": "T05",
+      "passed": true,
+      "title": "Capability list baseline"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'capabilities.overrides.send_email=confirm'",
+      "id": "T06",
+      "passed": true,
+      "title": "Capability override confirm"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Started session:'",
+      "id": "T07",
+      "passed": true,
+      "title": "Chat starts new session"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Resumed session:'",
+      "id": "T08",
+      "passed": true,
+      "title": "Chat resumes last session"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Action blocked by capability policy.'",
+      "id": "T09",
+      "passed": true,
+      "title": "Confirm action denied"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'capabilities.overrides.send_email=forbidden'",
+      "id": "T10",
+      "passed": true,
+      "title": "Capability override forbidden"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Action blocked by capability policy.'",
+      "id": "T11",
+      "passed": true,
+      "title": "Forbidden action blocked"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Review the Phase 1 roadmap'",
+      "id": "T12",
+      "passed": true,
+      "title": "Task capture"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Plain note for hardening'",
+      "id": "T13",
+      "passed": true,
+      "title": "Note capture"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Review the Phase 1 roadmap'",
+      "id": "T14",
+      "passed": true,
+      "title": "Tasks list all"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Review the Phase 1 roadmap'",
+      "id": "T15",
+      "passed": true,
+      "title": "Task filter query"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Hardening Summary Fixture'",
+      "id": "T16",
+      "passed": true,
+      "title": "Summarize URL"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Hardening Summary Fixture'",
+      "id": "T17",
+      "passed": true,
+      "title": "Summaries list"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Plan p'",
+      "id": "T18",
+      "passed": true,
+      "title": "Plan generation"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Updated plan'",
+      "id": "T19",
+      "passed": true,
+      "title": "Plan refinement"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Set up a personal knowledge base'",
+      "id": "T20",
+      "passed": true,
+      "title": "Plans list"
+    }
+  ],
+  "total": 20
+}

--- a/assistant/benchmark-results.json
+++ b/assistant/benchmark-results.json
@@ -1,0 +1,156 @@
+{
+  "failed": 0,
+  "methodology": {
+    "description": "Phase 1 canonical task pass/fail benchmark",
+    "runner": "tools/phase1-hardening.py",
+    "task_source": "assistant/canonical-tasks.md"
+  },
+  "passed": 20,
+  "schema_version": 1,
+  "score_pct": 100.0,
+  "suite": "phase1-canonical-benchmark",
+  "target_score_pct": 80.0,
+  "tasks": [
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'profile.name=HardeningUser'",
+      "id": "T01",
+      "passed": true,
+      "title": "Config set name"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'HardeningUser'",
+      "id": "T02",
+      "passed": true,
+      "title": "Config get name"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'profile.verbosity=concise'",
+      "id": "T03",
+      "passed": true,
+      "title": "Config set verbosity"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'profile.default_provider=openai'",
+      "id": "T04",
+      "passed": true,
+      "title": "Config set provider"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'send_email forbidden'",
+      "id": "T05",
+      "passed": true,
+      "title": "Capability list baseline"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'capabilities.overrides.send_email=confirm'",
+      "id": "T06",
+      "passed": true,
+      "title": "Capability override confirm"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Started session:'",
+      "id": "T07",
+      "passed": true,
+      "title": "Chat starts new session"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Resumed session:'",
+      "id": "T08",
+      "passed": true,
+      "title": "Chat resumes last session"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Action blocked by capability policy.'",
+      "id": "T09",
+      "passed": true,
+      "title": "Confirm action denied"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'capabilities.overrides.send_email=forbidden'",
+      "id": "T10",
+      "passed": true,
+      "title": "Capability override forbidden"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Action blocked by capability policy.'",
+      "id": "T11",
+      "passed": true,
+      "title": "Forbidden action blocked"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Review the Phase 1 roadmap'",
+      "id": "T12",
+      "passed": true,
+      "title": "Task capture"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Plain note for hardening'",
+      "id": "T13",
+      "passed": true,
+      "title": "Note capture"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Review the Phase 1 roadmap'",
+      "id": "T14",
+      "passed": true,
+      "title": "Tasks list all"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Review the Phase 1 roadmap'",
+      "id": "T15",
+      "passed": true,
+      "title": "Task filter query"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Hardening Summary Fixture'",
+      "id": "T16",
+      "passed": true,
+      "title": "Summarize URL"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Hardening Summary Fixture'",
+      "id": "T17",
+      "passed": true,
+      "title": "Summaries list"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Plan p'",
+      "id": "T18",
+      "passed": true,
+      "title": "Plan generation"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Updated plan'",
+      "id": "T19",
+      "passed": true,
+      "title": "Plan refinement"
+    },
+    {
+      "canonical_source": "assistant/canonical-tasks.md",
+      "details": "expected output to contain: 'Set up a personal knowledge base'",
+      "id": "T20",
+      "passed": true,
+      "title": "Plans list"
+    }
+  ],
+  "total": 20
+}

--- a/assistant/benchmarking.md
+++ b/assistant/benchmarking.md
@@ -1,0 +1,57 @@
+# Benchmark Methodology (Phase 1)
+
+This benchmark tracks quality on the 20 canonical Phase 1 assistant tasks.
+
+## Command Surface
+
+Run benchmark:
+
+```bash
+make benchmark
+```
+
+The command writes structured JSON results to:
+
+- `assistant/benchmark-results.json`
+
+Baseline artifact:
+
+- `assistant/benchmark-baseline.json`
+
+## Scoring
+
+- Task source: `assistant/canonical-tasks.md`
+- Runner source: `tools/phase1-hardening.py`
+- Benchmark wrapper: `tools/benchmark.py`
+- Score: `passed / total * 100`
+- Phase 1 success target: `>=80%`
+
+Each task emits:
+
+- task id (`T01`...`T20`)
+- title
+- pass/fail status
+- deterministic details string
+
+## Determinism Rules
+
+- Benchmark compares current run against `assistant/benchmark-baseline.json`.
+- Baseline is read-only during normal runs.
+- Benchmark fails on drift (task pass/fail or summary changes).
+- Baseline updates only when explicitly requested.
+
+## Updating Baseline
+
+Only update baseline after intentional behavior changes that should redefine
+expected quality:
+
+```bash
+python3 tools/benchmark.py --update-baseline
+```
+
+Review the resulting diff in `assistant/benchmark-baseline.json` before merge.
+
+## CI Integration
+
+`.github/workflows/benchmark.yml` runs `make benchmark` on PRs and main,
+and uploads `assistant/benchmark-results.json` as an artifact.

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Deterministic benchmark runner for Gaia Phase 1 canonical tasks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HARDENING_SCRIPT = REPO_ROOT / "tools" / "phase1-hardening.py"
+DEFAULT_JSON_OUT = REPO_ROOT / "assistant" / "benchmark-results.json"
+DEFAULT_BASELINE = REPO_ROOT / "assistant" / "benchmark-baseline.json"
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _write_json(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _run_phase1_hardening() -> Tuple[int, Dict[str, Any], str, str]:
+    json_out = REPO_ROOT / "assistant" / ".benchmark-phase1-hardening.json"
+    md_out = REPO_ROOT / "assistant" / ".benchmark-phase1-hardening.md"
+
+    env = os.environ.copy()
+    env["TZ"] = "UTC"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(HARDENING_SCRIPT),
+            "--json-out",
+            str(json_out),
+            "--md-out",
+            str(md_out),
+        ],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = _load_json(json_out)
+    try:
+        json_out.unlink(missing_ok=True)
+        md_out.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+    return proc.returncode, payload, proc.stdout.strip(), proc.stderr.strip()
+
+
+def _task_key(task_id: str) -> Tuple[int, str]:
+    raw = str(task_id).strip()
+    if raw.startswith("T") and raw[1:].isdigit():
+        return int(raw[1:]), raw
+    return 9999, raw
+
+
+def _build_benchmark_payload(hardening_payload: Dict[str, Any]) -> Dict[str, Any]:
+    raw_results = hardening_payload.get("results", [])
+    tasks: List[Dict[str, Any]] = []
+    if isinstance(raw_results, list):
+        for item in raw_results:
+            if not isinstance(item, dict):
+                continue
+            task_id = str(item.get("check_id", "")).strip()
+            title = str(item.get("title", "")).strip()
+            details = str(item.get("details", "")).strip()
+            if not task_id:
+                continue
+            tasks.append(
+                {
+                    "id": task_id,
+                    "title": title,
+                    "passed": bool(item.get("passed", False)),
+                    "details": details,
+                    "canonical_source": "assistant/canonical-tasks.md",
+                }
+            )
+
+    tasks.sort(key=lambda row: _task_key(str(row.get("id", ""))))
+    total = len(tasks)
+    passed = sum(1 for row in tasks if bool(row.get("passed", False)))
+    failed = total - passed
+    score_pct = round((passed / total) * 100, 2) if total else 0.0
+
+    return {
+        "schema_version": 1,
+        "suite": "phase1-canonical-benchmark",
+        "target_score_pct": 80.0,
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "score_pct": score_pct,
+        "tasks": tasks,
+        "methodology": {
+            "description": "Phase 1 canonical task pass/fail benchmark",
+            "task_source": "assistant/canonical-tasks.md",
+            "runner": "tools/phase1-hardening.py",
+        },
+    }
+
+
+def _compare_with_baseline(current: Dict[str, Any], baseline: Dict[str, Any]) -> List[str]:
+    drifts: List[str] = []
+
+    for key in ("suite", "schema_version", "total", "passed", "failed", "score_pct"):
+        if current.get(key) != baseline.get(key):
+            drifts.append(
+                f"summary mismatch for '{key}': current={current.get(key)!r} baseline={baseline.get(key)!r}"
+            )
+
+    current_tasks = current.get("tasks", [])
+    baseline_tasks = baseline.get("tasks", [])
+    if not isinstance(current_tasks, list) or not isinstance(baseline_tasks, list):
+        drifts.append("invalid task structure in current or baseline payload")
+        return drifts
+
+    current_index = {
+        str(item.get("id", "")).strip(): item
+        for item in current_tasks
+        if isinstance(item, dict)
+    }
+    baseline_index = {
+        str(item.get("id", "")).strip(): item
+        for item in baseline_tasks
+        if isinstance(item, dict)
+    }
+
+    current_ids = sorted([task_id for task_id in current_index if task_id])
+    baseline_ids = sorted([task_id for task_id in baseline_index if task_id])
+
+    if current_ids != baseline_ids:
+        drifts.append("task id set mismatch between current run and baseline")
+
+    shared_ids = sorted(set(current_ids).intersection(baseline_ids), key=_task_key)
+    for task_id in shared_ids:
+        current_item = current_index[task_id]
+        baseline_item = baseline_index[task_id]
+        if bool(current_item.get("passed", False)) != bool(baseline_item.get("passed", False)):
+            drifts.append(
+                f"task {task_id} pass/fail changed: current={bool(current_item.get('passed', False))} "
+                f"baseline={bool(baseline_item.get('passed', False))}"
+            )
+
+    return drifts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run Gaia canonical benchmark")
+    parser.add_argument("--json-out", default=str(DEFAULT_JSON_OUT), help="Path for benchmark output JSON")
+    parser.add_argument("--baseline", default=str(DEFAULT_BASELINE), help="Path to baseline JSON")
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="Overwrite baseline with the current benchmark output",
+    )
+    args = parser.parse_args()
+
+    json_out = Path(args.json_out).expanduser()
+    baseline_path = Path(args.baseline).expanduser()
+
+    rc, hardening_payload, hardening_stdout, hardening_stderr = _run_phase1_hardening()
+    if not hardening_payload:
+        print("Benchmark failed: could not read phase1-hardening output", file=sys.stderr)
+        if hardening_stdout:
+            print(hardening_stdout, file=sys.stderr)
+        if hardening_stderr:
+            print(hardening_stderr, file=sys.stderr)
+        return 1
+
+    benchmark_payload = _build_benchmark_payload(hardening_payload)
+    _write_json(json_out, benchmark_payload)
+
+    if args.update_baseline:
+        _write_json(baseline_path, benchmark_payload)
+        print(f"Updated baseline: {baseline_path}")
+    else:
+        baseline_payload = _load_json(baseline_path)
+        if not baseline_payload:
+            print(
+                f"Baseline not found at {baseline_path}. Run with --update-baseline to create it.",
+                file=sys.stderr,
+            )
+            return 1
+        drifts = _compare_with_baseline(benchmark_payload, baseline_payload)
+        if drifts:
+            print("Benchmark drift detected against baseline:", file=sys.stderr)
+            for item in drifts:
+                print(f"- {item}", file=sys.stderr)
+            print("Run with --update-baseline to accept this new baseline.", file=sys.stderr)
+            return 1
+
+    print(json.dumps(benchmark_payload, indent=2, sort_keys=True))
+    print(f"Benchmark results written to {json_out}")
+
+    if rc != 0:
+        print("Underlying hardening runner returned non-zero status.", file=sys.stderr)
+        if hardening_stdout:
+            print(hardening_stdout, file=sys.stderr)
+        if hardening_stderr:
+            print(hardening_stderr, file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add deterministic benchmark runner (`tools/benchmark.py`) for the 20 canonical Phase 1 tasks
- add baseline artifact + explicit baseline update flow (`assistant/benchmark-baseline.json`, `--update-baseline`)
- add benchmark docs (`assistant/benchmarking.md`) and `make benchmark`
- add PR CI workflow (`.github/workflows/benchmark.yml`) with benchmark artifact upload

## Validation
- `python3 -m py_compile tools/benchmark.py`
- `make benchmark`
- `make check-all`

## Issue
Closes #35
