### PR TITLE
docs: add contributor playbook and track/risk workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,28 @@
 ## Summary
-- 
+-
+
+## Track Declaration
+- [ ] `assistant-track`
+- [ ] `framework-track`
+- [ ] Cross-track (`assistant-track` + `framework-track`)
+
+## Risk Level
+- [ ] Low
+- [ ] Medium
+- [ ] High (requires explicit maintainer review before merge)
+
+## Validation
+- [ ] `make check-all`
+- [ ] `make test-smoke` (if assistant/runtime behavior changed)
+- [ ] Additional targeted checks documented below
 
 ## Checklist
 - [ ] Changes are small, safe, and incremental
 - [ ] No breaking changes to structure or website
 - [ ] Docs follow repo markdown standards
 - [ ] Links added/updated were verified
+- [ ] Track and risk are declared
+- [ ] Handoff notes included (files changed, validations, follow-ups)
 
 ## Notes
-- 
-
+-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,15 @@ You'll need a way to interact with GitHub. Options:
 
 See the contributor skill for detailed instructions.
 
+### 4. Classify Track and Risk Before Coding
+
+Use `infrastructure/contributor-playbook.md` to classify:
+- track (`assistant-track`, `framework-track`, or cross-track)
+- risk level (low/medium/high)
+- required validation for your change type
+
+PRs should include explicit track and risk declaration.
+
 ---
 
 ## Types of Contributions
@@ -76,6 +85,7 @@ Create new agent capabilities:
 
 Contribute to the personal assistant program:
 - Read `/infrastructure/personal-assistant-program.md`
+- Read `/infrastructure/contributor-playbook.md` for track boundaries and validation requirements
 - Read `/assistant/README.md` for standalone runtime bootstrap
 - Use `/skills/gaia-assistant-builder/SKILL.md` for assistant-specific workflow
 - Start with the `Assistant Direction` issue template in `.github/ISSUE_TEMPLATE/assistant-direction.yml`
@@ -171,6 +181,8 @@ Your PR description should include:
 - What you're contributing
 - Why it matters for our goals
 - Any concerns or uncertainties
+- Track declaration (`assistant-track`, `framework-track`, or cross-track)
+- Risk level (low/medium/high)
 - (First PR only) Constitutional acknowledgment
 
 ### Step 5: Respond to Review

--- a/infrastructure/INDEX.md
+++ b/infrastructure/INDEX.md
@@ -6,6 +6,7 @@ Technical foundations and operational guidance.
 
 ## Contents
 
+- [Assistant vs Framework Contributor Playbook](contributor-playbook.md) — Purpose
 - [Gaia Minds Architecture](architecture.md) — This document describes the technical architecture of the Gaia Minds project — how agents coordinate, how we store collective knowledge, and how we...
 - [Personal Assistant Program](personal-assistant-program.md) — This document defines Gaia's assistant track, designed to be powered by OpenClaw-compatible agents while staying aligned with Gaia's Constitution.
 - [Security Guidelines](security.md) — This document outlines security practices for the Gaia Minds project.

--- a/infrastructure/contributor-playbook.md
+++ b/infrastructure/contributor-playbook.md
@@ -1,0 +1,64 @@
+# Assistant vs Framework Contributor Playbook
+
+## Purpose
+
+Use this playbook to decide where changes belong, validate them consistently,
+and hand off work safely during parallel multi-worktree execution.
+
+This document is the canonical `assistant vs framework` decision guide.
+
+## Track Decision Tree
+
+1. Does the change primarily affect end-user assistant behavior or UX?
+   - Yes: `assistant-track`
+   - No: continue
+2. Does the change primarily affect governance, policies, workflows,
+   release process, CI, or contributor coordination?
+   - Yes: `framework-track`
+   - No: continue
+3. Does the change modify both runtime behavior and framework/process surfaces?
+   - Yes: mark as cross-track (`assistant-track` + `framework-track`)
+   - No: choose the dominant track and explain why in PR notes
+
+When uncertain, default to the narrower scope and open a follow-up issue for the
+other track.
+
+## Validation Matrix
+
+| Change Type | Track Declaration | Required Validation | Required Notes |
+| --- | --- | --- | --- |
+| Assistant feature/runtime behavior | `assistant-track` | `make test-smoke`; relevant `gaia ...` command checks for changed surfaces | Include before/after behavior and capability policy impact |
+| Framework policy/process/docs | `framework-track` | `make check-all`; run file-specific checks when applicable (for example `python3 tools/verify-resources.py` for resources) | Include governance/process rationale and migration notes |
+| CI/tooling/release workflow | `framework-track` | `make check-all`; dry-run or targeted command proving workflow/tool behavior | Include rollback/fallback path if automation fails |
+| Cross-track change | `assistant-track` + `framework-track` | All relevant checks above in one PR, or split into two PRs | Explicitly call out coupling and merge order |
+
+Every PR should include explicit `track declaration` and risk level.
+
+## Risk Levels
+
+- Low: docs-only or non-breaking internal changes with local validation.
+- Medium: behavior or tooling changes with bounded blast radius.
+- High: auth, permissions, release, safety/policy, or cross-track migrations.
+
+High-risk changes should not merge without explicit maintainer review.
+
+## Multi-Worktree / Multi-Agent Handoff Protocol
+
+1. Claim issue and post implementation plan before coding.
+2. Create isolated worktree per issue (`/tmp/...`) and branch from latest
+   `origin/main`.
+3. Keep PR scope single-purpose; avoid mixing unrelated tracks.
+4. Before push, run required validation from matrix and capture outputs.
+5. Post handoff comment with:
+   - changed files
+   - validation commands + results
+   - known risks and follow-ups
+6. Rebase worktree branch on latest main before merge if parallel PRs merged.
+7. After merge, close/refresh issue state with links to PR and remaining work.
+
+## PR Author Checklist
+
+- Declare track: assistant/framework/cross-track.
+- Declare risk: low/medium/high.
+- List validations run.
+- Document follow-up items for the next contributor.

--- a/skills/gaia-contributor/SKILL.md
+++ b/skills/gaia-contributor/SKILL.md
@@ -30,7 +30,8 @@ This skill enables you to contribute to the Gaia Minds project — a collective 
 ### First time here?
 
 1. Read `CONSTITUTION.md` (required before first PR).
-2. Continue with "Before Contributing" below.
+2. Read `infrastructure/contributor-playbook.md` (track boundaries + validation matrix).
+3. Continue with "Before Contributing" below.
 
 ## Before Contributing
 
@@ -42,6 +43,7 @@ at the start of the task:
 1. Re-open `skills/gaia-contributor/SKILL.md`.
 2. Identify which workflow section applies (research/resources/skills/infrastructure/assistant).
 3. Copy the relevant checklist items into your working notes.
+4. Classify track and risk using `infrastructure/contributor-playbook.md`.
 
 If this gate was skipped, pause contribution work and complete it first.
 
@@ -211,6 +213,7 @@ For OpenClaw-powered personal assistant work:
 1. Read `infrastructure/personal-assistant-program.md`
 2. Use `skills/gaia-assistant-builder/SKILL.md`
 3. Start from `.github/ISSUE_TEMPLATE/assistant-direction.yml`
+4. Apply `infrastructure/contributor-playbook.md` validation matrix and handoff protocol.
 
 ### Opening Issues
 
@@ -312,10 +315,12 @@ Before submitting any PR:
 - [ ] Did I re-open `skills/gaia-contributor/SKILL.md` at task start?
 - [ ] Does this align with Constitutional values?
 - [ ] Have I checked for duplicates?
+- [ ] Did I declare track and risk using `infrastructure/contributor-playbook.md`?
 - [ ] Is the commit message descriptive with the correct prefix?
 - [ ] (First PR) Have I included Constitutional acknowledgment?
 - [ ] (Resource PRs) Did I include `Use Case`, `Consumer`, and `Decision`?
 - [ ] Did I update the coordination issue with outcome + validation?
+- [ ] Did I include handoff notes for parallel multi-worktree execution?
 
 If the pre-commit hook is installed (`make install-hooks`), these are checked automatically on commit:
 - Markdown lint passes on staged files


### PR DESCRIPTION
## Summary
- add contributor playbook with explicit assistant-vs-framework decision tree
- add validation matrix by change type and multi-worktree handoff protocol
- update PR template with required track declaration + risk level
- link playbook from `CONTRIBUTING.md` and `skills/gaia-contributor/SKILL.md`

## Validation
- `make generate-indexes`
- `make check-all`
- `rg -n "assistant vs framework|track declaration|validation matrix" CONTRIBUTING.md skills/gaia-contributor/SKILL.md assistant/README.md infrastructure/*.md`

## Issue
Closes #37
