### PR TITLE
framework: add incident postmortem template and nightly benchmark trend

### DIFF
--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -1,0 +1,73 @@
+name: benchmark-nightly
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  benchmark-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run benchmark suite
+        id: benchmark
+        continue-on-error: true
+        run: make benchmark
+
+      - name: Update benchmark trend history
+        if: always()
+        run: |
+          python3 ./tools/benchmark-trend.py \
+            --results ./assistant/benchmark-results.json \
+            --history ./assistant/benchmark-trend-history.json \
+            --summary ./assistant/benchmark-trend-summary.md \
+            --runner-status "${{ steps.benchmark.outcome }}"
+
+      - name: Upload nightly benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-nightly-${{ github.run_id }}
+          path: |
+            assistant/benchmark-results.json
+            assistant/benchmark-trend-history.json
+            assistant/benchmark-trend-summary.md
+
+      - name: Commit nightly trend updates
+        if: always() && github.ref == 'refs/heads/main'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add assistant/benchmark-trend-history.json assistant/benchmark-trend-summary.md
+          if git diff --cached --quiet; then
+            echo "No benchmark trend updates to commit."
+          else
+            git commit -m "chore: update nightly benchmark trend [skip ci]"
+            git push
+          fi
+
+      - name: Fail workflow if benchmark failed
+        if: always()
+        run: |
+          if [ "${{ steps.benchmark.outcome }}" != "success" ]; then
+            echo "Benchmark step outcome: ${{ steps.benchmark.outcome }}"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - Roadmap/backlog reassessment issue template (`.github/ISSUE_TEMPLATE/roadmap-backlog-review.yml`)
 - Research synthesis playbook for backlog realism reviews (`research/synthesis/2026-02-roadmap-backlog-research-playbook.md`)
+- Incident/postmortem docs and reusable template (`docs/incidents/README.md`, `docs/incidents/postmortem-template.md`)
+- Nightly benchmark trend workflow (`.github/workflows/benchmark-nightly.yml`) with history/summary updates
+- Benchmark trend tool and local command (`tools/benchmark-trend.py`, `make benchmark-trend`)
 
 ### Changed
 - Refreshed roadmap and sprint status priorities to remove closed-item drift and reference reassessment issue `#46`
 - Synced latest release references to `@gaia-minds/assistant-cli@0.2.0` across top-level and assistant contributor docs
 - Added contributor guidance to use the roadmap/backlog review issue template for reassessment work
+- Expanded benchmark docs with nightly trend and incident linkage guidance
 
 ### Planned
 - Additional resource documentation

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs-check verify-resources generate-indexes check-indexes check-all test-smoke test-uat uat-policy benchmark hardening-phase1 install-hooks uninstall-hooks assistant-init assistant-onboard assistant-auth-status assistant-doctor assistant-run-dry
+.PHONY: docs-check verify-resources generate-indexes check-indexes check-all test-smoke test-uat uat-policy benchmark benchmark-trend hardening-phase1 install-hooks uninstall-hooks assistant-init assistant-onboard assistant-auth-status assistant-doctor assistant-run-dry
 
 docs-check:
 	./tools/validate-docs.sh
@@ -27,6 +27,9 @@ uat-policy:
 
 benchmark:
 	python3 ./tools/benchmark.py
+
+benchmark-trend:
+	python3 ./tools/benchmark-trend.py --results ./assistant/benchmark-results.json --history ./assistant/benchmark-trend-history.json --summary ./assistant/benchmark-trend-summary.md
 
 hardening-phase1:
 	python3 ./tools/phase1-hardening.py

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Core principles are defined in `CONSTITUTION.md`:
 - Contribution protocol: `CONTRIBUTING.md`
 - Security policy: `SECURITY.md`
 - Code of conduct: `CODE_OF_CONDUCT.md`
+- Incident/postmortem workflow: `docs/incidents/README.md`
 
 ## Coordination
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -23,13 +23,13 @@ See `ROADMAP.md` for full phase details and exit criteria.
 
 ## In Progress
 
-_No items claimed yet._
+- Incident/postmortem template and nightly benchmark trend workflow (`#48`)
 
 ## Next Up (Ordered)
 
-1. Execute roadmap/backlog reassessment issue and sequence next work (`#46`)
-2. Open scoped Phase 2 issues for recurring execution, reminders, and policy engine v1
-3. Define incident/postmortem template and nightly benchmark trend workflow
+1. Open scoped Phase 2 issues for recurring execution, reminders, and policy engine v1
+2. Implement recurring/scheduled execution once scoped issue is claimed
+3. Implement reminders + policy engine follow-up issues after scoping
 
 ## Blocked
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -142,10 +142,14 @@ Benchmark the 20 canonical Phase 1 tasks:
 
 ```bash
 make benchmark
+make benchmark-trend
 ```
 
 - Methodology and update process: `assistant/benchmarking.md`
 - Baseline artifact: `assistant/benchmark-baseline.json`
+- Trend history: `assistant/benchmark-trend-history.json`
+- Trend summary: `assistant/benchmark-trend-summary.md`
+- Incident postmortem template: `docs/incidents/postmortem-template.md`
 
 ## Terminal UAT
 

--- a/assistant/benchmark-trend-history.json
+++ b/assistant/benchmark-trend-history.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "suite": "phase1-canonical-benchmark",
+  "updated_at": "",
+  "entries": []
+}

--- a/assistant/benchmark-trend-summary.md
+++ b/assistant/benchmark-trend-summary.md
@@ -1,0 +1,5 @@
+# Benchmark Trend Summary
+
+Updated (UTC):
+
+No trend entries recorded yet.

--- a/assistant/benchmarking.md
+++ b/assistant/benchmarking.md
@@ -13,6 +13,8 @@ make benchmark
 The command writes structured JSON results to:
 
 - `assistant/benchmark-results.json`
+- `assistant/benchmark-trend-history.json` (when running `make benchmark-trend`)
+- `assistant/benchmark-trend-summary.md` (when running `make benchmark-trend`)
 
 Baseline artifact:
 
@@ -55,3 +57,32 @@ Review the resulting diff in `assistant/benchmark-baseline.json` before merge.
 
 `.github/workflows/benchmark.yml` runs `make benchmark` on PRs and main,
 and uploads `assistant/benchmark-results.json` as an artifact.
+
+Nightly trend workflow:
+
+- `.github/workflows/benchmark-nightly.yml` runs on a nightly UTC schedule and on manual dispatch.
+- It runs `make benchmark`, appends a new trend record, and updates:
+  - `assistant/benchmark-trend-history.json`
+  - `assistant/benchmark-trend-summary.md`
+- It uploads nightly artifacts for triage and long-term comparison.
+
+## Local Trend Updates
+
+```bash
+make benchmark
+make benchmark-trend
+```
+
+Use the summary to quickly inspect:
+
+- current benchmark status
+- score delta versus previous run
+- pass streak and recent run table
+
+## Incident and Postmortem Integration
+
+When nightly benchmarks fail or regressions are detected, open a postmortem
+using:
+
+- `docs/incidents/postmortem-template.md`
+- `docs/incidents/README.md`

--- a/docs/incidents/README.md
+++ b/docs/incidents/README.md
@@ -1,0 +1,38 @@
+# Incident and Postmortem Workflow
+
+Use this folder to document significant regressions and reliability incidents.
+
+## When to Create a Postmortem
+
+Create a postmortem when one of these occurs:
+
+- benchmark regression or drift on `main`
+- autopilot rollback or failed automation requiring manual intervention
+- CI reliability incident that blocks contributor throughput
+- policy/governance gate failure with user-facing or release impact
+
+## File Naming
+
+Create postmortems as:
+
+- `docs/incidents/YYYY-MM-DD-<short-slug>.md`
+
+Example:
+
+- `docs/incidents/2026-02-10-nightly-benchmark-regression.md`
+
+## Process
+
+1. Copy `docs/incidents/postmortem-template.md` into a new incident file.
+2. Fill in the timeline, impact, root cause, and corrective actions.
+3. Link to evidence: CI runs, logs, traces, and related PRs/issues.
+4. Add owners and due dates for remediation tasks.
+5. Keep status current until all actions are closed.
+
+## Required Evidence Sources
+
+- benchmark artifacts (`assistant/benchmark-results.json`)
+- benchmark trend summary (`assistant/benchmark-trend-summary.md`)
+- benchmark trend history (`assistant/benchmark-trend-history.json`)
+- relevant CI workflow run URLs
+- traces/logs tied to the incident

--- a/docs/incidents/postmortem-template.md
+++ b/docs/incidents/postmortem-template.md
@@ -1,0 +1,83 @@
+# Incident Postmortem Template
+
+Use this template for reliability and regression incidents.
+
+## Metadata
+
+- Incident ID:
+- Title:
+- Date detected (UTC):
+- Date resolved (UTC):
+- Severity: `sev1 | sev2 | sev3`
+- Status: `open | mitigated | resolved`
+- Owner:
+- Related issue(s):
+- Related PR(s):
+- Related workflow run(s):
+
+## Summary
+
+What happened, in one concise paragraph.
+
+## Impact
+
+- User impact:
+- Runtime impact:
+- CI/release impact:
+- Duration:
+
+## Detection
+
+- How was it detected?
+- First alert/signal (logs, workflow, user report):
+- Why detection did or did not happen early:
+
+## Timeline (UTC)
+
+| Time | Event | Owner |
+| --- | --- | --- |
+| 2026-02-10T03:20:00Z | Example: nightly benchmark failed on T14 | gaia-bot |
+
+## Root Cause Analysis
+
+### Immediate Cause
+
+What directly failed?
+
+### Contributing Factors
+
+What conditions made this more likely?
+
+### Why It Escaped Earlier Checks
+
+What guardrail was missing or insufficient?
+
+## Mitigation and Recovery
+
+- Short-term mitigation:
+- Recovery steps executed:
+- Rollback used? (`yes/no`) and details:
+
+## Corrective Actions
+
+| Action | Type (`prevention`/`detection`/`response`) | Owner | Due Date | Status |
+| --- | --- | --- | --- | --- |
+| Example: add benchmark scenario for edge case | prevention | @owner | 2026-02-15 | open |
+
+## Verification
+
+- Commands/checks run after fix:
+- Evidence links (artifacts, logs, traces):
+- Confirmation criteria met:
+
+## Lessons Learned
+
+- What we should repeat:
+- What we should stop doing:
+- What to automate next:
+
+## Follow-up Tracking
+
+- [ ] Actions linked to issue(s)
+- [ ] Actions scheduled/planned
+- [ ] Status reviewed in next sprint update

--- a/tools/benchmark-trend.py
+++ b/tools/benchmark-trend.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Append Gaia benchmark trend history and render a summary report.
+
+This tool is intended for nightly CI runs and local diagnostics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_RESULTS = REPO_ROOT / "assistant" / "benchmark-results.json"
+DEFAULT_HISTORY = REPO_ROOT / "assistant" / "benchmark-trend-history.json"
+DEFAULT_SUMMARY = REPO_ROOT / "assistant" / "benchmark-trend-summary.md"
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        return {}
+    return payload
+
+
+def _write_json(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _parse_ts(raw: str) -> datetime:
+    value = raw.strip()
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)
+
+
+def _read_results(path: Path) -> Dict[str, Any]:
+    payload = _load_json(path)
+    required_keys = {"suite", "total", "passed", "failed", "score_pct"}
+    if not required_keys.issubset(payload.keys()):
+        missing = ", ".join(sorted(required_keys - set(payload.keys())))
+        raise ValueError(f"Benchmark results missing keys: {missing}")
+    return payload
+
+
+def _normalized_runner_status(raw: str) -> str:
+    value = raw.strip().lower()
+    if value in {"success", "pass", "passed"}:
+        return "pass"
+    if value in {"failure", "fail", "failed", "cancelled", "canceled", "timed_out"}:
+        return "fail"
+    return "unknown"
+
+
+def _build_entry(results: Dict[str, Any], args: argparse.Namespace) -> Dict[str, Any]:
+    ts = args.timestamp or _iso_now()
+    run_id = args.run_id or os.environ.get("GITHUB_RUN_ID", "")
+    run_attempt = args.run_attempt or os.environ.get("GITHUB_RUN_ATTEMPT", "")
+    sha = args.sha or os.environ.get("GITHUB_SHA", "")
+    ref = args.ref or os.environ.get("GITHUB_REF_NAME", "")
+    event_name = args.event or os.environ.get("GITHUB_EVENT_NAME", "")
+    workflow = args.workflow or os.environ.get("GITHUB_WORKFLOW", "")
+    actor = args.actor or os.environ.get("GITHUB_ACTOR", "")
+
+    score_pct = float(results.get("score_pct", 0.0))
+    target_score_pct = float(results.get("target_score_pct", 0.0))
+    failed = int(results.get("failed", 0))
+
+    runner_status = _normalized_runner_status(args.runner_status)
+    benchmark_status = "pass" if failed == 0 and score_pct >= target_score_pct else "fail"
+    status = benchmark_status if runner_status == "unknown" else runner_status
+
+    return {
+        "timestamp_utc": ts,
+        "date_utc": ts[:10],
+        "suite": str(results.get("suite", "")).strip(),
+        "total": int(results.get("total", 0)),
+        "passed": int(results.get("passed", 0)),
+        "failed": failed,
+        "score_pct": round(score_pct, 2),
+        "target_score_pct": round(target_score_pct, 2),
+        "status": status,
+        "runner_status": runner_status,
+        "benchmark_status": benchmark_status,
+        "sha": sha,
+        "ref": ref,
+        "event_name": event_name,
+        "workflow": workflow,
+        "run_id": str(run_id).strip(),
+        "run_attempt": str(run_attempt).strip(),
+        "actor": actor,
+    }
+
+
+def _load_history(path: Path, suite: str) -> List[Dict[str, Any]]:
+    payload = _load_json(path)
+    entries = payload.get("entries", []) if isinstance(payload, dict) else []
+    if not isinstance(entries, list):
+        return []
+
+    cleaned: List[Dict[str, Any]] = []
+    for item in entries:
+        if not isinstance(item, dict):
+            continue
+        if suite and str(item.get("suite", "")).strip() and str(item.get("suite", "")).strip() != suite:
+            continue
+        cleaned.append(item)
+    return cleaned
+
+
+def _entry_key(entry: Dict[str, Any]) -> Tuple[str, str, str, str]:
+    return (
+        str(entry.get("run_id", "")).strip(),
+        str(entry.get("run_attempt", "")).strip(),
+        str(entry.get("sha", "")).strip(),
+        str(entry.get("timestamp_utc", "")).strip(),
+    )
+
+
+def _append_entry(entries: List[Dict[str, Any]], entry: Dict[str, Any], max_entries: int) -> Tuple[List[Dict[str, Any]], bool]:
+    key = _entry_key(entry)
+    for existing in entries:
+        if _entry_key(existing) == key:
+            return entries, False
+
+    merged = [*entries, entry]
+    merged.sort(key=lambda item: str(item.get("timestamp_utc", "")))
+    if max_entries > 0 and len(merged) > max_entries:
+        merged = merged[-max_entries:]
+    return merged, True
+
+
+def _score_stats(entries: List[Dict[str, Any]], days: int) -> Tuple[float, int]:
+    if not entries:
+        return 0.0, 0
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    scores: List[float] = []
+    for item in entries:
+        ts = str(item.get("timestamp_utc", "")).strip()
+        if not ts:
+            continue
+        try:
+            if _parse_ts(ts) < cutoff:
+                continue
+        except ValueError:
+            continue
+        scores.append(float(item.get("score_pct", 0.0)))
+
+    if not scores:
+        return 0.0, 0
+    return round(sum(scores) / len(scores), 2), len(scores)
+
+
+def _current_pass_streak(entries: List[Dict[str, Any]]) -> int:
+    streak = 0
+    for item in reversed(entries):
+        if str(item.get("status", "")).strip().lower() != "pass":
+            break
+        streak += 1
+    return streak
+
+
+def _render_summary(history_payload: Dict[str, Any]) -> str:
+    entries = history_payload.get("entries", [])
+    if not isinstance(entries, list):
+        entries = []
+
+    lines: List[str] = [
+        "# Benchmark Trend Summary",
+        "",
+        f"Updated (UTC): {history_payload.get('updated_at', '')}",
+        "",
+    ]
+
+    if not entries:
+        lines.append("No trend entries recorded yet.")
+        return "\n".join(lines) + "\n"
+
+    latest = entries[-1]
+    previous = entries[-2] if len(entries) > 1 else None
+
+    lines.extend(
+        [
+            "## Latest Run",
+            f"- status: `{latest.get('status', 'unknown')}`",
+            f"- score: `{latest.get('score_pct', 0):.2f}%`",
+            f"- passed: `{latest.get('passed', 0)}/{latest.get('total', 0)}`",
+            f"- benchmark_status: `{latest.get('benchmark_status', 'unknown')}`",
+            f"- run: `{latest.get('run_id', '')}` attempt `{latest.get('run_attempt', '')}`",
+            f"- commit: `{str(latest.get('sha', ''))[:12]}`",
+            f"- event: `{latest.get('event_name', '')}`",
+            "",
+        ]
+    )
+
+    if previous:
+        delta_score = round(float(latest.get("score_pct", 0.0)) - float(previous.get("score_pct", 0.0)), 2)
+        delta_passed = int(latest.get("passed", 0)) - int(previous.get("passed", 0))
+        lines.extend(
+            [
+                "## Delta Vs Previous",
+                f"- score_delta_pct: `{delta_score:+.2f}`",
+                f"- passed_delta: `{delta_passed:+d}`",
+                "",
+            ]
+        )
+
+    avg_7d, count_7d = _score_stats(entries, days=7)
+    pass_count = sum(1 for item in entries if str(item.get("status", "")).strip().lower() == "pass")
+    pass_rate = round((pass_count / len(entries)) * 100.0, 2) if entries else 0.0
+    streak = _current_pass_streak(entries)
+
+    lines.extend(
+        [
+            "## Window Stats",
+            f"- total_entries: `{len(entries)}`",
+            f"- pass_rate_pct: `{pass_rate:.2f}`",
+            f"- current_pass_streak: `{streak}`",
+            f"- avg_score_last_7d: `{avg_7d:.2f}` (from `{count_7d}` run(s))",
+            "",
+            "## Recent Runs",
+            "",
+            "| timestamp_utc | status | score_pct | passed | sha | run_id |",
+            "| --- | --- | ---: | ---: | --- | --- |",
+        ]
+    )
+
+    for item in reversed(entries[-14:]):
+        lines.append(
+            "| {ts} | {status} | {score:.2f} | {passed}/{total} | `{sha}` | `{run}` |".format(
+                ts=str(item.get("timestamp_utc", "")),
+                status=str(item.get("status", "unknown")),
+                score=float(item.get("score_pct", 0.0)),
+                passed=int(item.get("passed", 0)),
+                total=int(item.get("total", 0)),
+                sha=str(item.get("sha", ""))[:8],
+                run=str(item.get("run_id", "")),
+            )
+        )
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Update Gaia benchmark trend history and summary")
+    parser.add_argument("--results", default=str(DEFAULT_RESULTS), help="Path to benchmark-results.json")
+    parser.add_argument("--history", default=str(DEFAULT_HISTORY), help="Path to benchmark trend history JSON")
+    parser.add_argument("--summary", default=str(DEFAULT_SUMMARY), help="Path to benchmark trend summary markdown")
+    parser.add_argument("--max-entries", type=int, default=90, help="Maximum entries to keep in history")
+    parser.add_argument("--timestamp", default="", help="Override timestamp in UTC ISO8601")
+    parser.add_argument("--sha", default="", help="Commit SHA override")
+    parser.add_argument("--ref", default="", help="Ref name override")
+    parser.add_argument("--event", default="", help="Event name override")
+    parser.add_argument("--workflow", default="", help="Workflow name override")
+    parser.add_argument("--run-id", default="", help="Run ID override")
+    parser.add_argument("--run-attempt", default="", help="Run attempt override")
+    parser.add_argument("--actor", default="", help="Actor override")
+    parser.add_argument(
+        "--runner-status",
+        default="unknown",
+        help="Benchmark step status (success/failure/cancelled). Used for trend status.",
+    )
+    args = parser.parse_args()
+
+    results_path = Path(args.results).expanduser()
+    history_path = Path(args.history).expanduser()
+    summary_path = Path(args.summary).expanduser()
+
+    try:
+        results = _read_results(results_path)
+    except Exception as exc:
+        print(f"error: could not read benchmark results: {exc}")
+        return 1
+
+    suite = str(results.get("suite", "")).strip()
+    if not suite:
+        print("error: benchmark results missing suite")
+        return 1
+
+    history_entries = _load_history(history_path, suite=suite)
+    entry = _build_entry(results, args)
+    entries, appended = _append_entry(history_entries, entry, max_entries=args.max_entries)
+
+    payload = {
+        "schema_version": 1,
+        "suite": suite,
+        "updated_at": _iso_now(),
+        "entries": entries,
+    }
+    _write_json(history_path, payload)
+
+    summary = _render_summary(payload)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(summary, encoding="utf-8")
+
+    report = {
+        "history_path": str(history_path),
+        "summary_path": str(summary_path),
+        "entries": len(entries),
+        "appended": appended,
+        "latest_status": entry.get("status", "unknown"),
+        "latest_score_pct": entry.get("score_pct", 0.0),
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add incident response docs and reusable postmortem template under `docs/incidents/`
- add nightly benchmark trend workflow (`.github/workflows/benchmark-nightly.yml`)
- add benchmark trend tool (`tools/benchmark-trend.py`) plus seed history/summary artifacts
- add local make target for trend updates (`make benchmark-trend`)
- update benchmark/runtime docs and sprint status references for this work

## Track Declaration
- [ ] `assistant-track`
- [x] `framework-track`
- [ ] Cross-track (`assistant-track` + `framework-track`)

## Risk Level
- [ ] Low
- [x] Medium
- [ ] High (requires explicit maintainer review before merge)

## Validation
- [x] `make check-all`
- [ ] `make test-smoke` (if assistant/runtime behavior changed)
- [ ] `make test-uat` (required for assistant feature changes)
- [x] `python3 -m py_compile tools/benchmark.py tools/benchmark-trend.py`
- [x] `make benchmark`
- [x] `python3 tools/benchmark-trend.py --results assistant/benchmark-results.json --history /tmp/gaia-benchmark-trend-history.json --summary /tmp/gaia-benchmark-trend-summary.md --runner-status success`

## Checklist
- [x] Changes are small, safe, and incremental
- [x] No breaking changes to structure or website
- [x] Docs follow repo markdown standards
- [x] Links added/updated were verified
- [x] Track and risk are declared
- [x] Handoff notes included (files changed, validations, follow-ups)
- [x] New feature surfaces include UAT updates in this PR

## Notes
- Nightly workflow records trend data even if the benchmark step fails (`continue-on-error`) and fails the job at the end to keep signal quality.
- Trend commit message includes `[skip ci]` to avoid recursive workflow churn.

Closes #48
