### PR TITLE
docs: decompose phase 2 roadmap into parallel offload lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Benchmark trend tool and local command (`tools/benchmark-trend.py`, `make benchmark-trend`)
 - Skills + sandbox enablement synthesis from Agent Skills, Claude Code, and Codex docs (`research/synthesis/2026-02-skills-and-sandbox-enablement.md`)
 - Skill onboarding security validation synthesis with anti-malicious checks (`research/synthesis/2026-02-skill-onboarding-security-validation.md`)
+- Phase 2 lane implementation plan packets with architecture-delta requirements (`infrastructure/phase2-lane-implementation-plans.md`)
+- Memory-management research lane issue (`#60`) for options/tradeoffs before implementation
 
 ### Changed
 - Refreshed roadmap and sprint status priorities to remove closed-item drift and reference reassessment issue `#46`
@@ -31,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Expanded Phase 2 scope with skill onboarding security-gate requirements and validation-report criteria
 - Reorganized Phase 2 execution into explicit parallel lanes (`P2-A`..`P2-H`) for multi-agent offloading
 - Published Phase 2 parallel issue set (`#51`-`#58`) so lanes are claimable independently
+- Extended Phase 2 execution model to require per-lane implementation plans and include `P2-I` memory research
+- Updated contributor skill/playbook workflows to require lane plan packets before coding
 
 ### Planned
 - Additional resource documentation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,6 +89,7 @@ Assistant track outcomes:
 - Add proactive reminders with user-controlled cadence.
 - Add sandboxed code execution profile for coding tasks (`read-only` and `workspace-write`) with explicit user approvals.
 - Add pre-activation skill security checks (`gaia skills validate`) with actionable findings.
+- Add a memory-management research gate before implementation (options/tradeoffs/recommendation).
 
 Framework track outcomes:
 
@@ -100,6 +101,7 @@ Framework track outcomes:
 - Add rollback primitives for failed automation runs.
 - Add incident log schema and postmortem template for regressions.
 - Add skill/sandbox trace schema (skill id, source, tool calls, approval decisions, sandbox profile).
+- Require lane-level implementation plans (scope, architecture deltas, validations, rollback) before coding starts.
 
 Exit criteria:
 
@@ -119,6 +121,10 @@ Only two shared contracts must be frozen first:
 - Skill contract: metadata + capability declaration + trace identifiers
 - Sandbox contract: profile names + escalation rules + approval event schema
 
+Detailed implementation plans for each lane are tracked in
+`infrastructure/phase2-lane-implementation-plans.md`.
+Every lane issue should include that lane's plan packet before implementation.
+
 Parallel lanes:
 
 1. `P2-A Scheduler` - recurring/scheduled execution runtime and persistence (`#51`)
@@ -129,11 +135,14 @@ Parallel lanes:
 6. `P2-F Policy Engine` - risk/source/scope gating + per-skill tool allowlists (`#56`)
 7. `P2-G Audit & Traces` - skill/sandbox trace schema + incident linkage (`#57`)
 8. `P2-H Quality` - malicious-skill fixtures, UAT/benchmark expansion, compatibility matrix (`#58`)
+9. `P2-I Memory Research` - memory architecture options/tradeoffs and recommendation (`#60`)
 
 Integration order is intentionally light:
 
 - `P2-C` and `P2-E` publish contracts first.
 - `P2-D`, `P2-F`, and `P2-G` integrate against those contracts.
+- `P2-A` and `P2-B` can progress in parallel, with reminders building on scheduler events.
+- `P2-I` runs in parallel as a research gate and feeds follow-on implementation scope.
 - `P2-H` validates all lanes continuously and final hardening at the end.
 
 ## Phase 3: Framework Self-Evolution v1
@@ -248,10 +257,11 @@ Framework KPIs:
 
 ## Immediate 14-Day Priorities
 
-1. Freeze Skill + Sandbox contracts and start all Phase 2 lanes in parallel (`#51`-`#58`).
-2. Assign one owner per lane (`P2-A` to `P2-H`) and merge incrementally behind tests.
-3. Run daily cross-lane integration checks (policy compatibility + trace schema).
-4. Finish with hardening pass focused on malicious-skill validation and sandbox escalation controls.
+1. Freeze Skill + Sandbox contracts and post lane implementation plans with architecture deltas (`#51`-`#58`).
+2. Assign one owner per lane (`P2-A` to `P2-I`) and merge incrementally behind tests.
+3. Run memory-management research lane (`#60`) to produce recommendation before memory implementation.
+4. Run daily cross-lane integration checks (policy compatibility + trace schema).
+5. Finish with hardening pass focused on malicious-skill validation and sandbox escalation controls.
 
 ## Milestones Log
 
@@ -267,5 +277,6 @@ Framework KPIs:
 | 2026-02-08 | Skills/sandbox research synthesized | Added Phase 2 items from Agent Skills + Claude + Codex docs |
 | 2026-02-08 | Skill onboarding security research synthesized | Added Phase 2 validation-gate requirements for malicious-skill prevention |
 | 2026-02-08 | Phase 2 parallel lane issue set opened | Issues #51-#58 created for agent offloading |
+| 2026-02-08 | Memory-management research lane opened | Issue #60 tracks options/tradeoffs before design lock |
 
 This roadmap is a living document and should be updated at least weekly.

--- a/STATUS.md
+++ b/STATUS.md
@@ -28,6 +28,8 @@ _No items claimed yet._
 ## Next Up (Parallel Lanes)
 
 All lanes below are intended to be claimable in parallel after contract freeze.
+Before coding, each claimed lane must post its implementation plan (including
+architecture deltas) per `infrastructure/phase2-lane-implementation-plans.md`.
 
 1. `P2-A Scheduler` - recurring/scheduled execution runtime and persistence (`#51`)
 2. `P2-B Reminders` - proactive reminder workflows and cadence controls (`#52`)
@@ -37,6 +39,7 @@ All lanes below are intended to be claimable in parallel after contract freeze.
 6. `P2-F Policy Engine` - per-skill tool allowlists and risk/source/scope gating (`#56`)
 7. `P2-G Audit & Traces` - skill/sandbox trace schema and incident linkage (`#57`)
 8. `P2-H Quality` - malicious fixtures, UAT/benchmark expansion, compatibility matrix (`#58`)
+9. `P2-I Memory Research` - memory architecture options/tradeoffs and recommendation (`#60`)
 
 ## Blocked
 

--- a/infrastructure/INDEX.md
+++ b/infrastructure/INDEX.md
@@ -9,4 +9,5 @@ Technical foundations and operational guidance.
 - [Assistant vs Framework Contributor Playbook](contributor-playbook.md) — Purpose
 - [Gaia Minds Architecture](architecture.md) — This document describes the technical architecture of the Gaia Minds project — how agents coordinate, how we store collective knowledge, and how we...
 - [Personal Assistant Program](personal-assistant-program.md) — This document defines Gaia's assistant track, designed as a standalone, constitutionally aligned personal assistant runtime.
+- [Phase 2 Lane Implementation Plans](phase2-lane-implementation-plans.md) — Updated: February 8, 2026
 - [Security Guidelines](security.md) — This document outlines security practices for the Gaia Minds project.

--- a/infrastructure/contributor-playbook.md
+++ b/infrastructure/contributor-playbook.md
@@ -45,6 +45,9 @@ High-risk changes should not merge without explicit maintainer review.
 ## Multi-Worktree / Multi-Agent Handoff Protocol
 
 1. Claim issue and post implementation plan before coding.
+   - Include scope/non-goals, architecture deltas, CLI/API changes, validation,
+     rollback, and dependencies.
+   - Use `infrastructure/phase2-lane-implementation-plans.md` as the template.
 2. Create isolated worktree per issue (`/tmp/...`) and branch from latest
    `origin/main`.
 3. Keep PR scope single-purpose; avoid mixing unrelated tracks.
@@ -55,6 +58,9 @@ High-risk changes should not merge without explicit maintainer review.
    - known risks and follow-ups
 6. Rebase worktree branch on latest main before merge if parallel PRs merged.
 7. After merge, close/refresh issue state with links to PR and remaining work.
+
+If runtime architecture changed, update `infrastructure/architecture.md`. If it
+did not, say `No architecture delta` in PR notes.
 
 ## PR Author Checklist
 

--- a/infrastructure/phase2-lane-implementation-plans.md
+++ b/infrastructure/phase2-lane-implementation-plans.md
@@ -1,0 +1,183 @@
+# Phase 2 Lane Implementation Plans
+
+Updated: February 8, 2026
+
+## Purpose
+
+This document provides execution-ready implementation plans for the Phase 2
+parallel lanes. It exists to make agent offloading reliable: every lane has a
+clear scope, architecture delta, validation plan, and done criteria.
+
+## Required Plan Packet (Per Lane Issue)
+
+Before coding starts, each lane issue must include an implementation-plan
+comment with:
+
+1. Scope and non-goals
+2. Architecture deltas (modules, interfaces, data/config schema)
+3. CLI/API surfaces added or changed
+4. Validation commands and test coverage
+5. Rollback/fallback plan
+6. Dependencies on other lanes/contracts
+7. Open risks and unresolved questions
+
+## Architecture Update Rule
+
+Any PR that changes runtime architecture must update `infrastructure/architecture.md`
+with a `Phase 2 delta` section for that lane. If no architecture change is made,
+the PR notes must state `No architecture delta`.
+
+## Shared Contracts (Freeze First)
+
+- Skill contract: skill metadata, capability declarations, trace identifiers
+- Sandbox contract: profile names, escalation rules, approval event schema
+
+## Lane Plans
+
+### P2-A Scheduler (`#51`)
+
+- Objective: recurring/scheduled execution runtime with durable state.
+- Architecture changes:
+  - Add scheduler service (`assistant` runtime loop + trigger dispatcher).
+  - Add persisted schedule store (local DB/file-backed registry).
+  - Add schedule event model with deterministic next-run calculation.
+- CLI surface:
+  - `gaia schedule create/list/update/cancel`.
+- Validation:
+  - Unit tests for recurrence math/timezone handling.
+  - Restart/recovery test proving schedules survive process restarts.
+  - Smoke test for one-shot + recurring task execution.
+- Done criteria:
+  - Schedules execute at expected times with persisted state and traces.
+
+### P2-B Reminders (`#52`)
+
+- Objective: proactive reminders with user-controlled cadence.
+- Architecture changes:
+  - Add reminder domain model and reminder executor.
+  - Integrate reminder triggers with scheduler events from `P2-A`.
+  - Add user preference fields for cadence/quiet-hours defaults.
+- CLI surface:
+  - `gaia reminders add/list/snooze/dismiss`.
+- Validation:
+  - Reminder scheduling tests (including snooze and quiet-hours).
+  - End-to-end reminder flow in smoke/UAT suite.
+- Done criteria:
+  - Reminders trigger, respect user cadence controls, and are auditable.
+
+### P2-C Skills Runtime (`#53`)
+
+- Objective: first-class skill discovery/loading (`list`, `inspect`).
+- Architecture changes:
+  - Add skill registry/index model for local/project skill sources.
+  - Add loader that reads metadata eagerly and instructions lazily.
+  - Define compatibility checks for supported skill schema versions.
+- CLI surface:
+  - `gaia skills list`
+  - `gaia skills inspect <skill-id>`
+- Validation:
+  - Fixture-based loading tests across valid/invalid skill packages.
+  - CLI output contract tests.
+- Done criteria:
+  - Skills are discoverable, inspectable, and source/provenance visible.
+
+### P2-D Skill Validation (`#54`)
+
+- Objective: security and compatibility gate before skill activation.
+- Architecture changes:
+  - Add validator pipeline (schema, metadata, static checks, policy fit).
+  - Add finding severity model (`info/warn/high/critical`).
+  - Store validation artifacts for audit/reporting.
+- CLI surface:
+  - `gaia skills validate <path-or-skill-id>`.
+- Validation:
+  - Malicious/edge fixture corpus with expected findings.
+  - Blocking behavior tests for high-severity failures.
+- Done criteria:
+  - Skills that fail high-severity checks cannot be onboarded.
+
+### P2-E Sandbox (`#55`)
+
+- Objective: safe code execution profiles with explicit escalation approvals.
+- Architecture changes:
+  - Add sandbox runner abstraction with `read-only` and `workspace-write`.
+  - Add approval-event workflow for escalations.
+  - Enforce default network-deny policy unless explicitly enabled.
+- CLI/API surface:
+  - Sandbox profile selection exposed in execution path.
+- Validation:
+  - Tests for filesystem/network policy enforcement.
+  - Escalation prompt + decision logging tests.
+- Done criteria:
+  - No unapproved escalations; sandbox profile always traceable.
+
+### P2-F Policy Engine (`#56`)
+
+- Objective: centralized action gating by risk/source/scope + per-skill allowlists.
+- Architecture changes:
+  - Add policy evaluation layer executed before tool invocation.
+  - Add policy schema for capability risk levels and skill allowlists.
+  - Integrate user scope and approval requirements into decisions.
+- CLI/API surface:
+  - Policy decision traces visible through trace tooling.
+- Validation:
+  - Decision-table tests for allow/confirm/deny paths.
+  - Regression tests for bypass attempts and conflicting rules.
+- Done criteria:
+  - All automated actions route through policy engine with explicit decisions.
+
+### P2-G Audit and Traces (`#57`)
+
+- Objective: unify trace schema for skills, policy, sandbox, and incidents.
+- Architecture changes:
+  - Extend trace schema with skill/source/hash/policy/sandbox fields.
+  - Add correlation IDs linking runs, approvals, and incident reports.
+  - Add trace query/report helpers for incident triage.
+- CLI surface:
+  - `gaia traces` enhancements for filtering by skill/sandbox/policy outcome.
+- Validation:
+  - Schema compatibility tests and migration checks.
+  - UAT assertions that every skill-triggered run includes required metadata.
+- Done criteria:
+  - 100% of skill-triggered runs emit complete trace metadata.
+
+### P2-H Quality (`#58`)
+
+- Objective: harden system quality against malicious or incompatible skills.
+- Architecture changes:
+  - Add malicious-skill fixture set and compatibility matrix test data.
+  - Expand UAT and benchmark harness for skill/sandbox/policy flows.
+  - Add regression gates for validation/sandbox escape scenarios.
+- Validation:
+  - CI matrix across fixture classes and supported skill bundles.
+  - Failure triage output suitable for issue automation.
+- Done criteria:
+  - Quality suite reliably blocks regressions in validation/policy/sandbox.
+
+### P2-I Memory Research (`#60`)
+
+- Objective: produce a research-backed memory-management recommendation before
+  implementation.
+- Architecture research scope:
+  - Memory taxonomy (session, long-term user, project, safety/audit memory).
+  - Storage/retrieval alternatives and migration paths.
+  - Security/privacy controls (retention, consent, deletion guarantees).
+  - Failure modes (poisoning, stale recall, privacy leakage).
+- Deliverables:
+  - Synthesis report in `research/synthesis/` with option matrix.
+  - Proposed architecture deltas and follow-on implementation issues.
+  - Benchmark approach for memory quality and safety.
+- Done criteria:
+  - One recommended architecture with explicit tradeoffs and rollback path.
+
+## Dependency Summary
+
+- `P2-A`: independent
+- `P2-B`: depends on `P2-A` event contracts
+- `P2-C`: independent (must publish skill contract)
+- `P2-D`: depends on `P2-C` contract
+- `P2-E`: independent (must publish sandbox contract)
+- `P2-F`: depends on `P2-C` + `P2-E` contracts
+- `P2-G`: depends on `P2-C` + `P2-E` + `P2-F` outputs
+- `P2-H`: validates all lanes continuously
+- `P2-I`: independent research lane; feeds later memory implementation lanes

--- a/skills/gaia-contributor/SKILL.md
+++ b/skills/gaia-contributor/SKILL.md
@@ -23,10 +23,11 @@ This skill enables you to contribute to the Gaia Minds project — a collective 
 
 ### What to work on next
 
-1. Check `STATUS.md` and select one "Next Up" lane (`P2-A` to `P2-H`).
+1. Check `STATUS.md` and select one "Next Up" lane (`P2-A` to `P2-I`).
 2. Confirm lane issues: `gh issue list --repo Gaia-minds/gaia-minds --state open --limit 100 | rg '\[Phase 2\]\[P2-'`
 3. Claim one lane by posting owner + scope + ETA on the issue, then move it to "In Progress" in `STATUS.md`.
-4. Check `ROADMAP.md` "Phase 2 Parallel Lanes" for shared contracts before implementing.
+4. Post the lane implementation plan packet (scope, architecture deltas, validations, rollback) using `infrastructure/phase2-lane-implementation-plans.md`.
+5. Check `ROADMAP.md` "Phase 2 Parallel Lanes" for shared contracts before implementing.
 
 ### Active lane map (Phase 2)
 
@@ -38,6 +39,7 @@ This skill enables you to contribute to the Gaia Minds project — a collective 
 - `P2-F Policy Engine` (`#56`)
 - `P2-G Audit & Traces` (`#57`)
 - `P2-H Quality` (`#58`)
+- `P2-I Memory Research` (`#60`)
 
 Default rule: one lane per branch/worktree. Open a cross-lane PR only for contract freeze or integration fixes.
 
@@ -281,9 +283,10 @@ gh search prs "P2-C skills runtime" --repo gaia-minds/gaia-minds
 ### Claiming and releasing lane work
 
 1. Claim by commenting on the lane issue with owner, scope, and ETA.
-2. Start one focused branch for that lane.
-3. If blocked for >24h, post blocker details and unclaim so another agent can pick it up.
-4. When opening PR, link the lane issue and add validation notes.
+2. Post a lane plan packet (scope, architecture deltas, CLI/API changes, validation, rollback) before coding.
+3. Start one focused branch for that lane.
+4. If blocked for >24h, post blocker details and unclaim so another agent can pick it up.
+5. When opening PR, link the lane issue, validation notes, and architecture update details.
 
 ### Avoiding Duplication
 


### PR DESCRIPTION
## Summary

Reworked Phase 2 planning so work can be executed in parallel by multiple coding agents with minimal blocking.

## What changed

- Decomposed Phase 2 into explicit parallel lanes (`P2-A`..`P2-H`) in `ROADMAP.md`.
- Added lightweight integration/dependency model (contract freeze, then parallel execution).
- Replaced sequential immediate priorities with parallel execution priorities.
- Updated `STATUS.md` sprint context and "Next Up" to lane-based claimable tasks.
- Added lane issue references and milestone logging in roadmap.
- Updated changelog with parallel offload and issue-set publication note.

## New parallel lane issue set

- #51 `P2-A Scheduler`
- #52 `P2-B Reminders`
- #53 `P2-C Skills Runtime`
- #54 `P2-D Skill Validation`
- #55 `P2-E Sandbox`
- #56 `P2-F Policy Engine`
- #57 `P2-G Audit & Traces`
- #58 `P2-H Quality`

## Validation

- `make check-all`
  - passed
  - local note: `markdownlint-cli2` and `lychee` are not installed in this environment, so optional local checks were skipped by project script.

## Track / Risk

- Track: `framework-track`
- Risk: `low`
