### PR TITLE
docs(protocol): enforce remote-first sync before issue selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Updated README/CONTRIBUTING/contributor docs to direct onboarding through the new execution protocol
 - Clarified execution model to enforce two main roles (`planner`, `contributor`) with other skills treated as sub-roles
 - Added strict main-role/sub-role matrix and mandatory merge gates to the execution protocol
+- Added remote-first sync requirement so agents must refresh from `origin` before planning or issue selection
 
 ### Planned
 - Additional resource documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ Read `infrastructure/agent-execution-protocol.md` before selecting work.
 This protocol defines:
 
 - two main roles (`planner`, `contributor`) with required startup handshake
+- mandatory remote-first sync before selecting or planning work
 - autonomous issue selection for contributor-role work
 - strict sub-role matrix by main role + mandatory merge gates by work type
 - required plan packet + validation + state sync deliverables
@@ -141,6 +142,11 @@ Explore deep questions:
 
 Before starting:
 ```bash
+# Remote-first sync (required)
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+
 # Search issues for related topics
 gh issue list --search "your topic"
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ protocol for agent onboarding and execution.
 It defines:
 
 - main-role handshake (`planner` or `contributor`) before work starts
+- mandatory remote-first sync before any planning or issue claim
 - autonomous issue selection for contributor role
 - strict main-role/sub-role matrix + mandatory merge gates
 - required plan packet, validation, and state-sync outputs
@@ -112,6 +113,7 @@ Work autonomously on Gaia Minds using infrastructure/agent-execution-protocol.md
 Load CONSTITUTION.md and skills/gaia-contributor/SKILL.md first.
 Then ask me which main role to take: planner or contributor.
 Do not start work until I answer.
+Sync with remote first (`git fetch origin` + `git pull --ff-only origin main`).
 Use all other skills only as sub-roles under the chosen main role.
 Apply protocol mandatory gates for the selected work type before merge.
 ```

--- a/infrastructure/agent-execution-protocol.md
+++ b/infrastructure/agent-execution-protocol.md
@@ -63,42 +63,67 @@ Rules:
 2. Declare chosen main role in first issue/PR comment.
 3. Trigger sub-role skills only when task conditions require them.
 
+## Remote-First State Sync (Mandatory)
+
+Never decide work from local state alone. Sync with `origin` first.
+
+Required sequence before selecting/claiming work:
+
+1. Validate remote access:
+   - `git remote -v`
+   - `git fetch origin`
+2. Update local `main` from remote:
+   - `git checkout main`
+   - `git pull --ff-only origin main`
+3. If continuing from a feature branch:
+   - `git checkout <branch>`
+   - `git fetch origin`
+   - `git rebase origin/main` (or document why rebase is deferred)
+4. Verify remote collaboration state:
+   - `gh issue list --repo Gaia-minds/gaia-minds --state open --limit 100`
+   - `gh pr list --repo Gaia-minds/gaia-minds --state open`
+
+If remote checks fail (GitHub/API connectivity), stop autonomous selection and
+report a blocker instead of using stale local assumptions.
+
 ## Contributor Main Role: Autonomous Issue Selection
 
 Contributor-role agents should self-select work by default.
 
-1. Load required baseline context:
+1. Complete `Remote-First State Sync (Mandatory)`.
+2. Load required baseline context:
    - `CONSTITUTION.md`
    - `skills/gaia-contributor/SKILL.md`
    - `infrastructure/contributor-playbook.md`
-2. Scan open queue:
+3. Scan open queue:
    - `gh issue list --repo Gaia-minds/gaia-minds --state open --limit 100 | rg '\[Phase 2\]\[P2-'`
-3. Filter to ready items:
+4. Filter to ready items:
    - no active owner claim
    - dependencies unblocked
    - scope matches current skill set
-4. Pick highest-priority ready issue (priority from `STATUS.md`).
-5. Post claim comment before coding:
+5. Pick highest-priority ready issue (priority from `STATUS.md`).
+6. Post claim comment before coding:
    - owner
    - scope
    - ETA
    - role skill(s) to be used
-6. Post required plan packet before implementation.
-7. Move lane status to `In Progress` in `STATUS.md`.
-8. If blocked for >24h, post blocker details and unclaim.
+7. Post required plan packet before implementation.
+8. Move lane status to `In Progress` in `STATUS.md`.
+9. If blocked for >24h, post blocker details and unclaim.
 
 ## Planner Main Role: Planning Flow
 
 Planner-role agents should:
 
-1. Define planning scope and decision deadline.
-2. Use `infrastructure/planning-round-template.md`.
-3. Produce an execution-ready plan:
+1. Complete `Remote-First State Sync (Mandatory)`.
+2. Define planning scope and decision deadline.
+3. Use `infrastructure/planning-round-template.md`.
+4. Produce an execution-ready plan:
    - decomposed items/lanes
    - dependency and merge-order notes
    - unclear items requiring research
-4. Recommend owners and next actions.
-5. Sync state docs (`STATUS.md`, `ROADMAP.md`, `CHANGELOG.md`) or record no-change reason.
+5. Recommend owners and next actions.
+6. Sync state docs (`STATUS.md`, `ROADMAP.md`, `CHANGELOG.md`) or record no-change reason.
 
 ## Sub-Role Trigger Matrix (Strict)
 
@@ -170,6 +195,7 @@ Required startup:
 Do not start work until I answer with the main role.
 
 Then:
+- Run remote-first sync (`git fetch origin`, `git pull --ff-only origin main`, and check open issues/PRs on remote).
 - If planner: run a planning round and publish the planning artifact.
 - If contributor: select your own issue from the open Phase 2 queue, post claim + plan packet, then execute in a focused branch and open a PR.
 - Use only sub-roles allowed by the protocol matrix for your chosen main role.

--- a/infrastructure/contributor-playbook.md
+++ b/infrastructure/contributor-playbook.md
@@ -9,6 +9,7 @@ This document is the canonical `assistant vs framework` decision guide.
 For onboarding and autonomous issue selection rules, see
 `infrastructure/agent-execution-protocol.md`.
 Use its strict main-role/sub-role matrix and mandatory merge gates.
+Always perform remote-first sync before planning/claiming work.
 
 ## Track Decision Tree
 

--- a/skills/gaia-contributor/SKILL.md
+++ b/skills/gaia-contributor/SKILL.md
@@ -27,6 +27,7 @@ Use `infrastructure/agent-execution-protocol.md` as the single source of truth
 for:
 
 - main-role handshake (`planner` or `contributor`)
+- mandatory remote-first sync
 - autonomous issue selection
 - strict sub-role matrix and mandatory merge gates
 - required outputs and validation gates
@@ -34,11 +35,15 @@ for:
 
 ### What to work on next
 
-1. Check `STATUS.md` and select one "Next Up" lane (`P2-A` to `P2-I`).
-2. Confirm lane issues: `gh issue list --repo Gaia-minds/gaia-minds --state open --limit 100 | rg '\[Phase 2\]\[P2-'`
-3. Claim one lane by posting owner + scope + ETA on the issue, then move it to "In Progress" in `STATUS.md`.
-4. Post the lane implementation plan packet (scope, architecture deltas, validations, rollback) using `infrastructure/phase2-lane-implementation-plans.md`.
-5. Check `ROADMAP.md` "Phase 2 Parallel Lanes" for shared contracts before implementing.
+1. Remote-first sync:
+   - `git fetch origin`
+   - `git checkout main`
+   - `git pull --ff-only origin main`
+2. Check `STATUS.md` and select one "Next Up" lane (`P2-A` to `P2-I`).
+3. Confirm lane issues on remote: `gh issue list --repo Gaia-minds/gaia-minds --state open --limit 100 | rg '\[Phase 2\]\[P2-'`
+4. Claim one lane by posting owner + scope + ETA on the issue, then move it to "In Progress" in `STATUS.md`.
+5. Post the lane implementation plan packet (scope, architecture deltas, validations, rollback) using `infrastructure/phase2-lane-implementation-plans.md`.
+6. Check `ROADMAP.md` "Phase 2 Parallel Lanes" for shared contracts before implementing.
 
 ### Active lane map (Phase 2)
 


### PR DESCRIPTION
## Summary
- add mandatory remote-first sync section to the agent execution protocol
- require `git fetch origin` + `git pull --ff-only origin main` before planning or issue selection
- require remote issue/PR verification and blocker reporting when GitHub connectivity fails
- mirror this rule in README, CONTRIBUTING, contributor skill, and contributor playbook

## Why
Agents with local clones can otherwise act on stale local state. This update forces remote truth as the source of coordination decisions.

## Validation
- `make check-all`
