### PR TITLE
docs(protocol): tighten onboarding prompt instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,14 +109,18 @@ It defines:
 Quick onboarding prompt:
 
 ```text
-Work autonomously on Gaia Minds using infrastructure/agent-execution-protocol.md.
-Load CONSTITUTION.md and skills/gaia-contributor/SKILL.md first.
-Then ask me which main role to take: planner or contributor.
+Work autonomously on Gaia Minds.
+Read CONSTITUTION.md, skills/gaia-contributor/SKILL.md, and infrastructure/agent-execution-protocol.md.
+Follow infrastructure/agent-execution-protocol.md as your operating protocol.
+Ask me which main role to take: planner or contributor.
 Do not start work until I answer.
-Sync with remote first (`git fetch origin` + `git pull --ff-only origin main`).
+Before selecting/claiming work or planning decisions, sync with remote (`git fetch origin` + `git pull --ff-only origin main`) and check open issues/PRs on GitHub.
 Use all other skills only as sub-roles under the chosen main role.
 Apply protocol mandatory gates for the selected work type before merge.
 ```
+
+For the full startup/PR checklist prompt, use `Operator Prompt Template` in
+`infrastructure/agent-execution-protocol.md`.
 
 ## Repository Map
 

--- a/infrastructure/agent-execution-protocol.md
+++ b/infrastructure/agent-execution-protocol.md
@@ -189,15 +189,15 @@ Work autonomously on Gaia Minds using the agent execution protocol.
 Required startup:
 1) Read CONSTITUTION.md
 2) Read skills/gaia-contributor/SKILL.md
-3) Read infrastructure/agent-execution-protocol.md
+3) Read infrastructure/agent-execution-protocol.md and follow it as the operating protocol
 4) Ask me which main role to take: planner or contributor
 
 Do not start work until I answer with the main role.
 
 Then:
-- Run remote-first sync (`git fetch origin`, `git pull --ff-only origin main`, and check open issues/PRs on remote).
+- Run remote-first sync (`git fetch origin`, `git pull --ff-only origin main`, and check open issues/PRs on remote) before selecting/claiming work or planning decisions.
 - If planner: run a planning round and publish the planning artifact.
-- If contributor: select your own issue from the open Phase 2 queue, post claim + plan packet, then execute in a focused branch and open a PR.
+- If contributor: read infrastructure/contributor-playbook.md, then select your own issue from the open Phase 2 queue, post claim + plan packet, then execute in a focused branch and open a PR.
 - Use only sub-roles allowed by the protocol matrix for your chosen main role.
 - Satisfy mandatory merge gates for your work type before requesting merge.
 


### PR DESCRIPTION
## Summary
- make the onboarding prompt explicitly require reading and following `infrastructure/agent-execution-protocol.md`
- clarify that remote-first sync must happen before selecting/claiming work or planning decisions
- include contributor playbook read step in the operator template for contributor flows
- point README users to the full operator prompt template for complete startup/PR checklist

## Validation
- `make generate-indexes`
- `make check-all`

## Risks / Follow-ups
- low risk: docs-only wording change

## Context
- aligns README prompt wording with the protocol's mandatory remote-first rules and role/sub-role handshake
