### PR TITLE
docs(protocol): make startup ordering remote-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ Quick onboarding prompt:
 
 ```text
 Work autonomously on Gaia Minds.
-Read CONSTITUTION.md, skills/gaia-contributor/SKILL.md, and infrastructure/agent-execution-protocol.md.
+Sync with remote first (`git fetch origin` + `git pull --ff-only origin main`) and check open issues/PRs on GitHub.
+Then read CONSTITUTION.md, skills/gaia-contributor/SKILL.md, and infrastructure/agent-execution-protocol.md.
 Follow infrastructure/agent-execution-protocol.md as your operating protocol.
 Ask me which main role to take: planner or contributor.
 Do not start work until I answer.
-Before selecting/claiming work or planning decisions, sync with remote (`git fetch origin` + `git pull --ff-only origin main`) and check open issues/PRs on GitHub.
 Use all other skills only as sub-roles under the chosen main role.
 Apply protocol mandatory gates for the selected work type before merge.
 ```

--- a/infrastructure/agent-execution-protocol.md
+++ b/infrastructure/agent-execution-protocol.md
@@ -53,7 +53,7 @@ All other skills are sub-roles and must be used under one of the two main roles:
 
 ## Startup Handshake (Required)
 
-After reading repo context, the agent must ask:
+After completing remote-first sync and reading repo context, the agent must ask:
 
 `Which main role should I take: planner or contributor?`
 
@@ -187,15 +187,15 @@ Use this when onboarding an agent:
 Work autonomously on Gaia Minds using the agent execution protocol.
 
 Required startup:
-1) Read CONSTITUTION.md
-2) Read skills/gaia-contributor/SKILL.md
-3) Read infrastructure/agent-execution-protocol.md and follow it as the operating protocol
-4) Ask me which main role to take: planner or contributor
+1) Run remote-first sync (`git fetch origin`, `git pull --ff-only origin main`, and check open issues/PRs on remote)
+2) Read CONSTITUTION.md
+3) Read skills/gaia-contributor/SKILL.md
+4) Read infrastructure/agent-execution-protocol.md and follow it as the operating protocol
+5) Ask me which main role to take: planner or contributor
 
 Do not start work until I answer with the main role.
 
 Then:
-- Run remote-first sync (`git fetch origin`, `git pull --ff-only origin main`, and check open issues/PRs on remote) before selecting/claiming work or planning decisions.
 - If planner: run a planning round and publish the planning artifact.
 - If contributor: read infrastructure/contributor-playbook.md, then select your own issue from the open Phase 2 queue, post claim + plan packet, then execute in a focused branch and open a PR.
 - Use only sub-roles allowed by the protocol matrix for your chosen main role.


### PR DESCRIPTION
## Summary
- make onboarding ordering explicit: remote sync first, then read protocol/context, then ask for main role
- align `README.md` quick prompt with remote-first behavior for stale-local-repo prevention
- align `infrastructure/agent-execution-protocol.md` operator template and startup handshake wording with the same order

## Why
Agents with an existing local clone can otherwise read stale docs/protocols before syncing. This change enforces remote-first startup to reduce stale-state decisions.

## Validation
- `make generate-indexes`
- `make check-all`

## Risk
- low (docs-only)
