### PR TITLE
docs(prompt): include full repo URL in onboarding prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ Quick onboarding prompt:
 
 ```text
 Work autonomously on Gaia Minds.
-Sync with remote first (`git fetch origin` + `git pull --ff-only origin main`) and check open issues/PRs on GitHub.
+Target repository: https://github.com/Gaia-minds/gaia-minds.git (Gaia-minds/gaia-minds).
+Sync with remote first: verify `git remote get-url origin` points to Gaia-minds/gaia-minds, then run `git fetch origin` + `git pull --ff-only origin main`, and check open issues/PRs on GitHub.
 Then read CONSTITUTION.md, skills/gaia-contributor/SKILL.md, and infrastructure/agent-execution-protocol.md.
 Follow infrastructure/agent-execution-protocol.md as your operating protocol.
 Ask me which main role to take: planner or contributor.

--- a/infrastructure/agent-execution-protocol.md
+++ b/infrastructure/agent-execution-protocol.md
@@ -70,6 +70,7 @@ Never decide work from local state alone. Sync with `origin` first.
 Required sequence before selecting/claiming work:
 
 1. Validate remote access:
+   - `git remote get-url origin` (must point to `Gaia-minds/gaia-minds`, HTTPS or SSH)
    - `git remote -v`
    - `git fetch origin`
 2. Update local `main` from remote:
@@ -187,11 +188,12 @@ Use this when onboarding an agent:
 Work autonomously on Gaia Minds using the agent execution protocol.
 
 Required startup:
-1) Run remote-first sync (`git fetch origin`, `git pull --ff-only origin main`, and check open issues/PRs on remote)
-2) Read CONSTITUTION.md
-3) Read skills/gaia-contributor/SKILL.md
-4) Read infrastructure/agent-execution-protocol.md and follow it as the operating protocol
-5) Ask me which main role to take: planner or contributor
+1) Confirm repository target is https://github.com/Gaia-minds/gaia-minds.git (or SSH equivalent) using `git remote get-url origin`
+2) Run remote-first sync (`git fetch origin`, `git pull --ff-only origin main`, and check open issues/PRs on remote)
+3) Read CONSTITUTION.md
+4) Read skills/gaia-contributor/SKILL.md
+5) Read infrastructure/agent-execution-protocol.md and follow it as the operating protocol
+6) Ask me which main role to take: planner or contributor
 
 Do not start work until I answer with the main role.
 


### PR DESCRIPTION
## Summary
- add the full target repository URL to the README quick onboarding prompt
- require explicit remote verification (`git remote get-url origin`) against `Gaia-minds/gaia-minds` before sync
- update protocol operator template startup steps with the same repository target check
- extend remote-first sync section with the same remote URL verification command

## Validation
- `make generate-indexes`
- `make check-all`

## Risk
- low (docs-only)
