### PR TITLE
docs(planning): post-phase2 reassessment and phase3 queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Planning/research/doc/review templates for consistent role execution quality (`infrastructure/*-template.md`)
 - New role skills: planner, researcher, technical writer, security reviewer, QA evaluator, release manager, incident responder, integration coordinator, privacy-memory steward
 - Agent execution protocol with autonomous issue selection, skill-trigger matrix, output contract, and operator prompt templates (`infrastructure/agent-execution-protocol.md`)
+- Post-Phase-2 reassessment planning-round artifact and kickoff queue decomposition for Phase 3 (`infrastructure/planning-round-2026-02-13-post-phase2-reassessment.md`, `#84`)
+- Phase 3 kickoff issue set for evidence rubric, hypothesis pipeline v1, and reliability baseline checkpoint (`#85`, `#86`, `#87`)
 
 ### Changed
 - Assistant architecture docs now include Phase 2 scheduler delta details (`infrastructure/architecture.md`)
@@ -105,6 +107,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Clarified execution model to enforce two main roles (`planner`, `contributor`) with other skills treated as sub-roles
 - Added strict main-role/sub-role matrix and mandatory merge gates to the execution protocol
 - Added remote-first sync requirement so agents must refresh from `origin` before planning or issue selection
+- Refreshed roadmap/status to reflect completed Phase 2 delivery and queued Phase 3 kickoff priorities (`ROADMAP.md`, `STATUS.md`)
 
 ### Planned
 - Additional resource documentation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Gaia Minds Roadmap
 
-Updated: February 8, 2026
+Updated: February 13, 2026
 
 This roadmap is now optimized for fast execution.
 
@@ -77,8 +77,8 @@ Exit criteria:
 
 ## Phase 2: Trusted Automation
 
-Timeline: February 15 to February 28, 2026
-Status: Planned
+Timeline: February 9 to February 13, 2026
+Status: Completed (delivered early as of February 13, 2026)
 
 Assistant track outcomes:
 
@@ -112,6 +112,12 @@ Exit criteria:
 - Zero unapproved sandbox escalations in CI and terminal UAT suites.
 - Zero onboarding of skills that fail high-severity security validation checks.
 - 100% of onboarded skills include immutable source/hash and validation report artifacts.
+
+Delivery snapshot:
+
+- Core Phase 2 lanes delivered: `#51` to `#58` and `#60`.
+- Memory implementation follow-on lanes delivered: `#75`, `#76`, `#77`, `#78`.
+- Deterministic gate coverage active across smoke/UAT/policy/quality/benchmark workflows.
 
 ### Phase 2 Parallel Lanes (Agent-Offload Ready)
 
@@ -258,11 +264,11 @@ Framework KPIs:
 
 ## Immediate 14-Day Priorities
 
-1. Freeze Skill + Sandbox contracts and post lane implementation plans with architecture deltas (`#51`-`#58`).
-2. Assign one owner per lane (`P2-A` to `P2-I`) and merge incrementally behind tests.
-3. Run memory-management research lane (`#60`) to produce recommendation before memory implementation.
-4. Run daily cross-lane integration checks (policy compatibility + trace schema).
-5. Finish with hardening pass focused on malicious-skill validation and sandbox escalation controls.
+1. Complete roadmap/state alignment pass and keep docs in sync with delivered Phase 2 state (`#84`).
+2. Ship self-evolution PR evidence rubric and enforcement baseline (`#85`).
+3. Start hypothesis pipeline v1 (proposal -> eval -> evidence) using rubric contracts (`#86`).
+4. Publish reliability baseline checkpoint and SLO-style thresholds for Phase 3 work (`#87`).
+5. Re-run planning review on February 16, 2026 with updated queue/metrics evidence.
 
 ## Milestones Log
 
@@ -279,5 +285,8 @@ Framework KPIs:
 | 2026-02-08 | Skill onboarding security research synthesized | Added Phase 2 validation-gate requirements for malicious-skill prevention |
 | 2026-02-08 | Phase 2 parallel lane issue set opened | Issues #51-#58 created for agent offloading |
 | 2026-02-08 | Memory-management research lane opened | Issue #60 tracks options/tradeoffs before design lock |
+| 2026-02-13 | Phase 2 lane execution completed | Issues #51-#58, #60, #75-#78 merged |
+| 2026-02-13 | Post-Phase-2 reassessment started | Issue #84 + planning round artifact |
+| 2026-02-13 | Phase 3 kickoff issue set opened | Issues #85, #86, #87 |
 
 This roadmap is a living document and should be updated at least weekly.

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,7 +4,7 @@ Updated: February 13, 2026
 
 ## Current Sprint
 
-**Phase 2 Parallel Buildout** (Feb 9–28, 2026)
+**Post-Phase-2 Reassessment + Phase 3 Kickoff** (Feb 13–28, 2026)
 
 See `ROADMAP.md` for full phase details and exit criteria.
 
@@ -36,17 +36,13 @@ See `ROADMAP.md` for full phase details and exit criteria.
 
 ## In Progress
 
-_Nothing currently in progress._
+- `Roadmap/Backlog Reassessment` - post-Phase-2 planning artifact + state sync (`#84`) - owner: `codex-gpt5`
 
-## Next Up (Parallel Lanes)
+## Next Up (Kickoff Queue)
 
-All lanes below are intended to be claimable in parallel after contract freeze.
-Before coding, each claimed lane must post its implementation plan (including
-architecture deltas) per `infrastructure/phase2-lane-implementation-plans.md`.
-Cross-cutting requirement: run a docs freshness sweep with
-`skills/gaia-technical-writer/SKILL.md` after merge batches.
-
-_Nothing currently queued._
+1. `Phase 3` - self-evolution PR evidence rubric (`#85`)
+2. `Phase 3` - hypothesis pipeline v1: proposal -> eval -> evidence (`#86`)
+3. `Phase 3` - reliability baseline checkpoint + SLO thresholds (`#87`)
 
 ## Blocked
 

--- a/infrastructure/INDEX.md
+++ b/infrastructure/INDEX.md
@@ -16,6 +16,7 @@ Technical foundations and operational guidance.
 - [Phase 2 Lane Implementation Plans](phase2-lane-implementation-plans.md) — Updated: February 8, 2026
 - [Phase 2 Planning Round - 2026-02-08](planning-round-2026-02-08-phase2.md) — Updated: February 8, 2026 Coordinator: Codex (planner main role) Activated sub-roles: `gaia-planner`, `gaia-integration-coordinator`...
 - [Planning Round Template](planning-round-template.md) — Updated: February 8, 2026
+- [Post-Phase-2 Reassessment Planning Round - 2026-02-13](planning-round-2026-02-13-post-phase2-reassessment.md) — Updated: February 13, 2026 Coordinator: Codex (planner main role) Activated sub-roles: `gaia-integration-coordinator`, `gaia-technical-writer`...
 - [Privacy and Memory Review Template](privacy-memory-review-template.md) — Updated: February 8, 2026
 - [QA Evaluation Template](qa-evaluation-template.md) — Updated: February 8, 2026
 - [Release Readiness Template](release-readiness-template.md) — Updated: February 8, 2026

--- a/infrastructure/planning-round-2026-02-13-post-phase2-reassessment.md
+++ b/infrastructure/planning-round-2026-02-13-post-phase2-reassessment.md
@@ -1,0 +1,133 @@
+# Post-Phase-2 Reassessment Planning Round - 2026-02-13
+
+Updated: February 13, 2026
+Coordinator: Codex (planner main role)
+Activated sub-roles: `gaia-integration-coordinator`, `gaia-technical-writer`,
+`gaia-researcher`
+
+## 1. Planning Question
+
+- Decision to make: close Phase 2 planning loop, refresh roadmap/state docs,
+  and seed the next execution queue for Phase 3 kickoff.
+- Decision deadline: February 13, 2026.
+- Scope boundary: planning and queue decomposition only; no runtime feature
+  implementation.
+
+## 2. Inputs Reviewed
+
+- `ROADMAP.md`:
+  - marked `Updated: February 8, 2026` with stale Phase 2 status and immediate
+    priorities that no longer match delivered state.
+- `STATUS.md`:
+  - all Phase 2 lanes through `#78` are shipped; no active queue items.
+- `CHANGELOG.md`:
+  - includes delivered memory lane records through `#78`.
+- Issues/PRs (live snapshot on 2026-02-13):
+  - open issues: `0` before opening reassessment work item.
+  - open PRs: `0`.
+
+## 3. Current State Snapshot
+
+- Shipped:
+  - Phase 1 and full Phase 2 lane set delivered (scheduler/reminders,
+    skills/sandbox/policy/trace, quality, memory runtime/retrieval/policy,
+    memory QA red-team harness).
+- In progress:
+  - none.
+- Blocked:
+  - none.
+- Risk hotspots:
+  - roadmap freshness drift after rapid merge cadence.
+  - no active queue after Phase 2 completion, which can stall throughput.
+  - Phase 3 acceptance/evidence standards need clearer execution contract.
+
+## 4. Proposed Work Items
+
+### Item `#85` - Self-evolution PR evidence rubric
+
+- Scope and non-goals:
+  - Scope: define minimum required evidence for self-evolution PRs and add
+    deterministic coverage/checks.
+  - Non-goal: rollout engine behavior changes.
+- Architecture deltas:
+  - process/governance contract only (templates + policy checks).
+- Validation plan:
+  - deterministic template/check validation in CI/local workflows.
+- Rollback/fallback:
+  - keep rubric check warn-only until edge cases are resolved, then enforce.
+- Acceptance criteria:
+  - rubric documented, referenced, and validated.
+- Owner recommendation:
+  - framework contributor with QA/governance workflow focus.
+
+### Item `#86` - Hypothesis pipeline v1 (proposal -> eval -> evidence)
+
+- Scope and non-goals:
+  - Scope: add first operational hypothesis artifact/report pipeline.
+  - Non-goal: auto-merge or production auto-rollout.
+- Architecture deltas:
+  - new hypothesis artifact and deterministic evidence output path.
+- Validation plan:
+  - one end-to-end dry-run from proposal to PR-ready evidence bundle.
+- Rollback/fallback:
+  - keep pipeline manual-trigger and dry-run capable while stabilizing.
+- Acceptance criteria:
+  - reproducible evidence generation and explicit failure/rollback output.
+- Owner recommendation:
+  - framework contributor with eval harness/tooling focus.
+
+### Item `#87` - Reliability baseline checkpoint + SLO thresholds
+
+- Scope and non-goals:
+  - Scope: define baseline metrics/thresholds and reproducible checkpoint
+    reporting.
+  - Non-goal: feature expansion unrelated to reliability gates.
+- Architecture deltas:
+  - reporting/triage contract only.
+- Validation plan:
+  - deterministic baseline artifact generation and threshold breach handling.
+- Rollback/fallback:
+  - fallback to previous baseline snapshot if checkpoint artifact is invalid.
+- Acceptance criteria:
+  - baseline + triage workflow documented and linked from core docs.
+- Owner recommendation:
+  - framework contributor with QA/operations focus.
+
+## 5. Dependencies and Merge Order
+
+- Shared contracts:
+  - `#85` evidence rubric should merge before `#86` and `#87` hard-gate usage.
+- Item dependencies:
+  - `#86` depends on `#85`.
+  - `#87` depends on `#85`.
+- Parallelization notes:
+  - after `#85`, `#86` and `#87` can run in parallel in isolated branches.
+
+## 6. Unclear Items Requiring Research
+
+- Unknown: minimum acceptable evidence set for rollout decisions without causing
+  review bottlenecks.
+  - Why blocked: unclear threshold can produce inconsistent merge quality.
+  - Required research output: repo-native evidence rubric with examples.
+- Unknown: delegation/routing policy bounds before broad multi-agent runtime.
+  - Why blocked: unclear risk envelope for delegated high-impact actions.
+  - Required research output: constrained policy proposal with deny/confirm
+    boundaries.
+
+## 7. State Sync Checklist
+
+- [x] `STATUS.md` updated with next queue items (`#85`, `#86`, `#87`).
+- [x] `ROADMAP.md` updated to reflect Phase 2 completion and new immediate
+  priorities.
+- [x] `CHANGELOG.md` updated to record this reassessment/planning round.
+- [x] Coordination issue comment posted.
+
+## 8. Exit
+
+- Final decision:
+  - close out Phase 2 planning state and start a Phase 3 kickoff queue with
+    evidence-first governance (`#85`) as prerequisite.
+- Next review date:
+  - February 16, 2026.
+- Open follow-ups:
+  - claim and execute `#85`, then run `#86` and `#87` in parallel.


### PR DESCRIPTION
## Summary
- add a formal post-Phase-2 planning artifact: `infrastructure/planning-round-2026-02-13-post-phase2-reassessment.md`
- refresh roadmap freshness in `ROADMAP.md`:
  - update last-updated date to February 13, 2026
  - mark Phase 2 as completed
  - replace stale 14-day priorities with post-Phase-2 kickoff priorities
  - append milestone entries for Phase 2 completion and new kickoff queue creation
- update `STATUS.md` to reflect active reassessment in progress and seed next queue entries
- update `CHANGELOG.md` with reassessment and queue decomposition records
- refresh `infrastructure/INDEX.md`

Closes #84.

## Planner Output
- Main role: `planner`
- Activated sub-roles: `gaia-integration-coordinator`, `gaia-technical-writer`, `gaia-researcher`
- New kickoff issues opened from this reassessment:
  - #85
  - #86
  - #87

## Validation
- `make generate-indexes`
- `make check-all`

## State Sync
- `STATUS.md`: updated
- `ROADMAP.md`: updated
- `CHANGELOG.md`: updated
