### PR TITLE
docs(planning): lock user-intent signal decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Post-Phase-3-delivery issue set for dead-code audit, assistant modular refactor, live-preview refresh, and npm release `0.3.0` (`#105`, `#106`, `#107`, `#108`)
 - User-intent signal architecture planning-round artifact for privacy-preserving self-evolution inputs and skill-first gap routing (`infrastructure/planning-round-2026-02-14-user-intent-signal-architecture.md`, `#110`)
 - Signal-driven self-evolution follow-on issue set for unmet-intent extraction, skill-first triage, and hypothesis integration (`#111`, `#112`, `#113`)
+- Continuous security-validation research lane for broad-source skill import hardening against prompt-injection and malicious instruction attacks (`#115`)
 
 ### Changed
 - PR template now includes explicit self-evolution applicability gating and required evidence fields (`.github/pull_request_template.md`)
@@ -152,6 +153,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Refreshed roadmap/status to reflect Phase 3 kickoff completion (`#87` / PR `#91`) and the newly published post-kickoff queue (`#93`-`#97`) (`ROADMAP.md`, `STATUS.md`)
 - Refreshed roadmap/status to reflect the post-delivery stabilization queue and merge order (`#105`-`#108`) (`ROADMAP.md`, `STATUS.md`)
 - Refreshed roadmap/status with a post-release signal-driven evolution queue (`#111`-`#113`) and privacy rule for derived user-intent signals only (`ROADMAP.md`, `STATUS.md`)
+- Locked signal-driven queue decisions: broad-source skill candidates with security validation gates, default-on signal capture with opt-out, and 90-day derived-signal retention (`ROADMAP.md`, `STATUS.md`, `#111`, `#112`, `#113`)
 
 ### Planned
 - Additional resource documentation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -205,20 +205,24 @@ Execution queue (signal-driven self-evolution follow-on; planning published):
 
 - `#110` Planning lane for user-intent signal architecture and queue decomposition
 - `#111` Privacy-preserving unmet-intent signal extraction from local interaction artifacts
-- `#112` Skill-first triage for unmet-intent signals (`existing-skill-enable` / `skill-import-candidate` / `core-feature-gap`)
+- `#112` Skill-first triage for unmet-intent signals (`existing-skill-enable` / `skill-import-candidate` / `core-feature-gap`) with broad-source import candidates gated by security validation
 - `#113` Integrate unmet-intent signal aggregates into hypothesis candidate generation
+- `#115` Continuous security validation research for broad-source skill imports (parallel support lane)
 
 Recommended merge order:
 
 1. `#111`
-2. `#112`
-3. `#113`
+2. `#115` (parallel support lane)
+3. `#112`
+4. `#113`
 
 Privacy/architecture rule for this queue:
 
 - only derived/sanitized interaction signals may feed self-evolution inputs;
   raw conversation transcripts must not be exported into hypothesis/evidence
   artifacts.
+- signal capture is default-on with explicit opt-out control.
+- derived-signal retention default is 90 days with deterministic bounded storage.
 
 Exit criteria:
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -56,8 +56,9 @@ _Nothing in progress._
 
 ## Planned Next Wave (Signal-Driven Evolution Follow-On)
 
-- `#111` `[Phase 3][Framework]` Privacy-preserving unmet-intent signal extraction from user interactions (after `#108`)
-- `#112` `[Phase 3][Framework]` Skill-first triage for unmet-intent signals (`existing-skill-enable` / `skill-import-candidate` / `core-feature-gap`) (depends on `#111`)
+- `#111` `[Phase 3][Framework]` Privacy-preserving unmet-intent signal extraction from user interactions (default-on + opt-out, 90-day retention) (after `#108`)
+- `#115` `[Phase 3][Framework][Research]` Continuous security validation research for broad-source skill imports (parallel support lane)
+- `#112` `[Phase 3][Framework]` Skill-first triage for unmet-intent signals (`existing-skill-enable` / `skill-import-candidate` / `core-feature-gap`) with broad-source import candidates gated by security validation (depends on `#111`, informed by `#115`)
 - `#113` `[Phase 3][Framework]` Integrate unmet-intent signals into hypothesis candidate generation (depends on `#111` + `#112`)
 
 ## Blocked

--- a/infrastructure/planning-round-2026-02-14-user-intent-signal-architecture.md
+++ b/infrastructure/planning-round-2026-02-14-user-intent-signal-architecture.md
@@ -44,6 +44,7 @@ Activated sub-roles: `gaia-planner`, `gaia-researcher`,
 - Issues/PRs:
   - planning lane published: `#110`
   - follow-on queue published: `#111`, `#112`, `#113`
+  - continuous security-research lane published: `#115`
 
 ## 3. Current State Snapshot
 
@@ -82,6 +83,10 @@ Activated sub-roles: `gaia-planner`, `gaia-researcher`,
     `intent-signals.jsonl`) under assistant local state.
   - add deterministic signal extraction pass over existing local artifacts.
   - expose signal inspection CLI path for user/human review.
+  - product decision lock:
+    - collection default is `on`
+    - explicit opt-out control is required
+    - retention default for derived signals is `90 days` with deterministic cap
 - Validation plan:
   - deterministic extraction fixtures
   - redaction/no-raw-transcript assertions
@@ -115,6 +120,10 @@ Activated sub-roles: `gaia-planner`, `gaia-researcher`,
   - add triage decision layer consuming `#111` signals + skills registry context.
   - emit triage artifacts with confidence and rationale.
   - add policy hooks for unsafe skill-candidate rejection.
+  - product decision lock:
+    - broader non-local skill sources are permitted as candidates
+    - all such candidates must pass security validation gates before activation
+    - prompt-injection and malicious-instruction checks are mandatory
 - Validation plan:
   - fixture-based decision matrix with expected classes
   - policy bypass/unsafe candidate rejection checks
@@ -144,6 +153,10 @@ Activated sub-roles: `gaia-planner`, `gaia-researcher`,
 - Architecture deltas:
   - extend hypothesis candidate generation inputs with intent-signal aggregates.
   - define contract fields linking candidate to signal evidence summary.
+  - enforce upstream product lock constraints:
+    - derived-signal-only input policy
+    - opt-out-aware candidate generation behavior
+    - evidence windows bounded by `90-day` retention policy
 - Validation plan:
   - deterministic candidate-generation fixtures
   - threshold behavior checks (`hold` when data is insufficient/noisy)
@@ -164,6 +177,32 @@ Activated sub-roles: `gaia-planner`, `gaia-researcher`,
     - `gaia-qa-evaluator`
     - self-evolution evidence rubric + CI check
 
+### Item `#115` - Continuous security validation research for broad-source skill imports
+
+- Scope and non-goals:
+  - Scope:
+    - maintain an ongoing research loop for skill-validation defenses against
+      prompt-injection and malicious-instruction attacks.
+    - publish actionable validation-rule deltas for contributor lanes.
+  - Non-goal:
+    - direct runtime rollout without linked implementation issue/PR.
+- Architecture deltas:
+  - no immediate runtime delta; research-to-implementation handoff contract.
+- Validation plan:
+  - periodic synthesis artifact publication and adversarial fixture proposals.
+- Evidence contract (self-evolution applicability):
+  - Not applicable unless research lane directly changes self-evolution runtime
+    behavior.
+- Rollback/fallback:
+  - if research findings are inconclusive, hold policy changes and keep current
+    validation thresholds.
+- Acceptance criteria:
+  - recurring security research outputs are linked into skill-triage/validation
+    lanes and reduce blind spots over time.
+- Owner recommendation:
+  - contributor with `gaia-researcher`; add `gaia-security-reviewer` when
+    findings trigger runtime/policy changes.
+
 ## 5. Dependencies and Merge Order
 
 - Shared contracts:
@@ -174,15 +213,18 @@ Activated sub-roles: `gaia-planner`, `gaia-researcher`,
   - memory privacy consent/retention controls
 - Item dependencies:
   - `#111` must land before downstream triage/generation.
-  - `#112` depends on `#111`.
+  - `#112` depends on `#111` and should consume `#115` research updates.
   - `#113` depends on `#111` + `#112`.
+  - `#115` runs in parallel and continuously informs `#112`/future skill-import
+    lanes.
 - Parallelization notes:
   - design/prototyping can run in parallel, but merge order should remain strict
     to avoid contract churn.
 - Recommended order:
   1. `#111`
-  2. `#112`
-  3. `#113`
+  2. `#115` (parallel supporting lane)
+  3. `#112`
+  4. `#113`
 
 ## 6. Unclear Items Requiring Research
 


### PR DESCRIPTION
## Summary
- lock user-provided decisions into the signal-driven self-evolution queue:
  - broad-source skill candidates allowed, but gated by security validation
  - signal collection defaults to on, with explicit opt-out
  - derived-signal retention default set to 90 days (bounded)
- add continuous research support lane for skill-import security hardening:
  - `#115`
- sync planner/state docs accordingly:
  - `infrastructure/planning-round-2026-02-14-user-intent-signal-architecture.md`
  - `ROADMAP.md`
  - `STATUS.md`
  - `CHANGELOG.md`
- update live issue specs for `#111`, `#112`, and `#113` with decision-lock sections

## Track Declaration
- [ ] `assistant-track`
- [x] `framework-track`
- [ ] Cross-track (`assistant-track` + `framework-track`)

## Risk Level
- [x] Low
- [ ] Medium
- [ ] High (requires explicit maintainer review before merge)

## Self-Evolution Applicability
- [ ] Applies: this PR changes self-evolution behavior/governance.
- [x] Not applicable: no self-evolution behavior/governance changes.

## Self-Evolution Evidence (required when applicability is "Applies")
- Baseline evidence: Not applicable
- Delta observed: Not applicable
- Thresholds and guardrails: Not applicable
- Rollback/fallback: Not applicable
- Risk notes: Not applicable

## Validation
- [x] `make check-all`
- [ ] `make test-smoke` (if assistant/runtime behavior changed)
- [ ] `make test-uat` (required for assistant feature changes)
- [x] Additional targeted checks documented below

Additional targeted checks:
- `make generate-indexes`

## Checklist
- [x] Changes are small, safe, and incremental
- [x] No breaking changes to structure or website
- [x] Docs follow repo markdown standards
- [x] Links added/updated were verified
- [x] Track and risk are declared
- [x] Self-evolution applicability declared and rubric completed when required
- [x] Handoff notes included (files changed, validations, follow-ups)
- [ ] New feature surfaces include UAT updates in this PR

## UAT Change Justification
- Not applicable. No UAT governance files changed.

## Notes
- Main role: `planner`
- Planner sub-roles activated: `gaia-planner`, `gaia-researcher`, `gaia-integration-coordinator`, `gaia-technical-writer`, `gaia-privacy-memory-steward`
- `#115` is designed as an ongoing research support lane that informs `#112` and future broad-source skill import work.

Refs #111
Refs #112
Refs #113
Refs #115
