### PR TITLE
docs: refresh assistant live preview assets (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Continuous security-validation research lane for broad-source skill import hardening against prompt-injection and malicious instruction attacks (`#115`)
 - Dead-code/dead-artifact audit report with keep/remove/defer classification and follow-up mapping (`infrastructure/dead-code-artifact-audit-2026-02-14.md`, `#105`)
 - Assistant CLI parser modularization via extracted parser builder module (`tools/gaia_assistant_parser.py`) while preserving stable runtime entrypoint (`tools/gaia-assistant.py`) (`#106`)
+- Refreshed live-preview terminal/animated assets for current assistant command surfaces (response profiles, feedback capture, memory summarize, traces) (`assistant/assets/gaia-assistant-terminal.svg`, `assistant/assets/gaia-assistant-demo-animated.svg`, `#107`)
 
 ### Changed
 - PR template now includes explicit self-evolution applicability gating and required evidence fields (`.github/pull_request_template.md`)
@@ -159,6 +160,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Locked signal-driven queue decisions: broad-source skill candidates with security validation gates, default-on signal capture with opt-out, and 90-day derived-signal retention (`ROADMAP.md`, `STATUS.md`, `#111`, `#112`, `#113`)
 - Refreshed roadmap/status to reflect dead-code/dead-artifact audit delivery and remaining stabilization merge order (`ROADMAP.md`, `STATUS.md`, `#105`)
 - Assistant architecture/docs and package payload now declare parser module boundaries and npm compatibility for modular CLI parser construction (`infrastructure/architecture.md`, `assistant/README.md`, `package.json`, `#106`)
+- Refreshed root/assistant README live-preview references with explicit source-of-truth asset mapping for docs freshness (`README.md`, `assistant/README.md`, `#107`)
 
 ### Planned
 - Additional resource documentation

--- a/README.md
+++ b/README.md
@@ -48,16 +48,21 @@ See `assistant/README.md` for full runtime and release docs.
 - Default token budget split: `80%` user service, `20%` self-improvement
 - Token budget enforcement includes deterministic per-cycle + per-track caps with explicit breach action (`warn`/`defer`/`block`)
 - Assistant feedback loop supports deterministic local capture of `helpful` / `not helpful` signals with optional correction notes and trace/session linkage
+- Chat supports deterministic response profiles (`auto`, `concise`, `balanced`, `detailed`) with config + override selection
+- Memory summarization supports traceable profile-aware compaction via `gaia memory summarize`
 
 ### Live Preview
 
-Terminal snapshot (current npm-based flow):
+Terminal snapshot (refreshed for current command surfaces on February 14, 2026):
 
 ![Gaia assistant terminal preview](assistant/assets/gaia-assistant-terminal.svg)
 
-Animated walkthrough:
+Animated walkthrough (same capability flow):
 
 ![Gaia assistant animated walkthrough](assistant/assets/gaia-assistant-demo-animated.svg)
+
+Source-of-truth mapping for these assets (command capture flow + file links):
+`assistant/README.md#live-preview-freshness-note`.
 
 ## What Gaia Is
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -191,13 +191,12 @@ Execution queue (post-delivery stabilization round):
 
 - `#105` Dead-code/dead-artifact audit across runtime/docs/release surfaces (delivered)
 - `#106` Modular refactor of `tools/gaia-assistant.py` command/runtime surfaces (delivered)
-- `#107` README live-preview asset refresh for current CLI capabilities (depends on `#106`)
+- `#107` README live-preview asset refresh for current CLI capabilities (delivered)
 - `#108` npm release `@gaia-minds/assistant-cli@0.3.0` readiness + publish (depends on `#106`, `#107`)
 
 Recommended merge order:
 
-1. `#107`
-2. `#108`
+1. `#108`
 
 Execution queue (signal-driven self-evolution follow-on; planning published):
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -44,6 +44,7 @@ See `ROADMAP.md` for full phase details and exit criteria.
 - `Phase 3 Personalized Response Profiles + Memory Summarization` - deterministic profile-aware chat style selection, `gaia memory summarize` with source traceability ledger, and summarize benchmark gate (`#97`)
 - `Phase 3 Dead-Code/Dead-Artifact Audit` - repository-wide keep/remove/defer audit artifact with high-confidence runtime cleanup of unused assistant helpers (`#105`)
 - `Phase 3 Assistant Modular Refactor` - extracted CLI parser construction into dedicated module with stable entrypoint/package compatibility and no command-surface regression (`#106`)
+- `Phase 3 README Live-Preview Refresh` - updated terminal/animated assistant assets and source-of-truth mapping for current command surfaces (`#107`)
 
 ## In Progress
 
@@ -51,7 +52,6 @@ _Nothing in progress._
 
 ## Next Up (Post-Phase-3 Delivery Queue)
 
-- `#107` `[Phase 3][Assistant]` Refresh README live preview assets for current CLI capabilities (depends on `#106`)
 - `#108` `[Phase 3][Release]` Prepare and publish npm release `@gaia-minds/assistant-cli@0.3.0` (depends on `#106` + `#107`)
 
 ## Planned Next Wave (Signal-Driven Evolution Follow-On)

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -56,6 +56,22 @@ npm install -g .
 gaia doctor
 ```
 
+## Live Preview Freshness Note
+
+README live-preview assets are refreshed to match current CLI behavior and are
+mapped to this source-of-truth command flow:
+
+1. `gaia doctor`
+2. `gaia chat --response-profile concise`
+3. `gaia feedback record --label not-helpful --session-id <session> --trace-id <trace> ...`
+4. `gaia memory summarize --subject user:preview --response-profile concise --json`
+5. `gaia traces --type feedback_record --last 1`
+
+Asset mapping:
+
+- Terminal snapshot: `assistant/assets/gaia-assistant-terminal.svg`
+- Animated walkthrough: `assistant/assets/gaia-assistant-demo-animated.svg`
+
 ## Provider Onboarding
 
 Run the guided onboarding wizard:

--- a/assistant/assets/gaia-assistant-demo-animated.svg
+++ b/assistant/assets/gaia-assistant-demo-animated.svg
@@ -1,33 +1,39 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="760" viewBox="0 0 1280 760" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="820" viewBox="0 0 1280 820" fill="none">
   <defs>
     <style>
       .frame { fill: #0B1220; }
       .panel { fill: #101A2E; stroke: #2A3C64; }
       .titlebar { fill: #172440; }
-      .text { fill: #D8E5FF; font-family: monospace; font-size: 18px; }
-      .cmd { fill: #8CE99A; font-family: monospace; font-size: 20px; }
-      .ok { fill: #8CE99A; font-family: monospace; font-size: 18px; }
-      .warn { fill: #F7D070; font-family: monospace; font-size: 18px; }
+      .title { fill: #D8E5FF; font-family: monospace; font-size: 20px; }
+      .cmd { fill: #8CE99A; font-family: monospace; font-size: 19px; }
+      .ok { fill: #8CE99A; font-family: monospace; font-size: 17px; }
+      .warn { fill: #F7D070; font-family: monospace; font-size: 17px; }
+      .text { fill: #CBD9F8; font-family: monospace; font-size: 17px; }
+      .meta { fill: #9AB6E9; font-family: monospace; font-size: 16px; }
       .line {
         opacity: 0;
-        animation: reveal 13s linear infinite;
+        animation: reveal 16s linear infinite;
       }
       .l1 { animation-delay: 0.2s; }
       .l2 { animation-delay: 0.8s; }
-      .l3 { animation-delay: 1.5s; }
-      .l4 { animation-delay: 2.1s; }
-      .l5 { animation-delay: 2.7s; }
-      .l6 { animation-delay: 3.3s; }
+      .l3 { animation-delay: 1.4s; }
+      .l4 { animation-delay: 2.0s; }
+      .l5 { animation-delay: 2.8s; }
+      .l6 { animation-delay: 3.4s; }
       .l7 { animation-delay: 4.0s; }
-      .l8 { animation-delay: 4.7s; }
+      .l8 { animation-delay: 4.6s; }
       .l9 { animation-delay: 5.4s; }
       .l10 { animation-delay: 6.1s; }
       .l11 { animation-delay: 6.8s; }
-      .l12 { animation-delay: 7.5s; }
+      .l12 { animation-delay: 7.6s; }
       .l13 { animation-delay: 8.2s; }
       .l14 { animation-delay: 8.9s; }
       .l15 { animation-delay: 9.6s; }
-      .l16 { animation-delay: 10.3s; }
+      .l16 { animation-delay: 10.4s; }
+      .l17 { animation-delay: 11.0s; }
+      .l18 { animation-delay: 11.6s; }
+      .l19 { animation-delay: 12.2s; }
+      .l20 { animation-delay: 12.8s; }
       .cursor {
         animation: blink 1s steps(1, end) infinite;
       }
@@ -35,7 +41,7 @@
       .bar-fill {
         fill: #8CE99A;
         transform-origin: 0 0;
-        animation: fillbar 13s linear infinite;
+        animation: fillbar 16s linear infinite;
       }
       @keyframes reveal {
         0% { opacity: 0; }
@@ -48,46 +54,51 @@
         100% { opacity: 0; }
       }
       @keyframes fillbar {
-        0% { transform: scaleX(0.03); }
-        20% { transform: scaleX(0.18); }
-        45% { transform: scaleX(0.44); }
-        70% { transform: scaleX(0.75); }
+        0% { transform: scaleX(0.04); }
+        25% { transform: scaleX(0.24); }
+        50% { transform: scaleX(0.52); }
+        75% { transform: scaleX(0.82); }
         100% { transform: scaleX(1); }
       }
     </style>
   </defs>
 
-  <rect class="frame" width="1280" height="760" rx="20"/>
-  <rect class="panel" x="34" y="28" width="1212" height="704" rx="16"/>
+  <rect class="frame" width="1280" height="820" rx="20"/>
+  <rect class="panel" x="34" y="28" width="1212" height="764" rx="16"/>
   <rect class="titlebar" x="34" y="28" width="1212" height="54" rx="16"/>
   <circle cx="72" cy="55" r="8" fill="#FF5F57"/>
   <circle cx="100" cy="55" r="8" fill="#FEBC2E"/>
   <circle cx="128" cy="55" r="8" fill="#28C840"/>
-  <text x="160" y="62" class="text" font-size="20">gaia-assistant animated walkthrough (current npm flow)</text>
+  <text x="160" y="62" class="title">gaia assistant animated walkthrough (doctor/chat/feedback/memory/traces)</text>
 
-  <text x="64" y="120" class="cmd line l1">$ npm install -g @gaia-minds/assistant-cli</text>
-  <text x="64" y="148" class="text line l2">changed 1 package in 261ms</text>
+  <text x="64" y="122" class="cmd line l1">$ gaia doctor</text>
+  <text x="64" y="150" class="ok line l2">[ok]</text>
+  <text x="118" y="150" class="text line l2">required command found: python3</text>
+  <text x="64" y="176" class="warn line l3">[warn]</text>
+  <text x="136" y="176" class="text line l3">launcher config not found yet - run `gaia init` or `gaia onboard`</text>
 
-  <text x="64" y="190" class="cmd line l3">$ gaia doctor</text>
-  <text x="64" y="218" class="text line l4">Gaia assistant doctor</text>
-  <text x="64" y="246" class="ok line l5">[ok]</text>
-  <text x="118" y="246" class="text line l5">required command found: python3</text>
-  <text x="64" y="274" class="ok line l6">[ok]</text>
-  <text x="118" y="274" class="text line l6">optional command found: codex</text>
-  <text x="64" y="302" class="warn line l7">[warn]</text>
-  <text x="136" y="302" class="text line l7">no linked OAuth profile in launcher config</text>
-  <text x="64" y="330" class="text line l8">run `gaia onboard`</text>
+  <text x="64" y="222" class="cmd line l4">$ gaia chat --response-profile concise</text>
+  <text x="64" y="250" class="text line l5">Started session: s20260214162721-fe6476</text>
+  <text x="64" y="276" class="text line l6">Response profile: concise (override)</text>
+  <text x="64" y="302" class="text line l7">gaia&gt; [local-openai][profile=concise] Need concise updates</text>
 
-  <text x="64" y="380" class="cmd line l9">$ gaia run --mode single --dry-run</text>
-  <text x="64" y="408" class="text line l10">17:02:14 [INFO] Loaded config: gaia-agent v0.1.0</text>
-  <text x="64" y="436" class="text line l11">17:02:14 [INFO] Active track: assistant (service=80%, self_improvement=20%)</text>
-  <text x="64" y="464" class="text line l12">17:02:14 [INFO] No actions proposed this cycle.</text>
-  <text x="64" y="492" class="ok line l13">17:02:14 [INFO] Cycle 1 complete: 0 succeeded, 0 failed</text>
+  <text x="64" y="348" class="cmd line l8">$ gaia feedback record --label not-helpful --session-id &lt;session&gt; --trace-id &lt;trace&gt;</text>
+  <text x="64" y="376" class="text line l9">feedback_id=fb20260214162721-bfb4e2 label=not-helpful session+trace linked</text>
 
-  <rect x="64" y="538" width="1150" height="16" rx="8" class="bar-bg"/>
-  <rect x="64" y="538" width="1150" height="16" rx="8" class="bar-fill"/>
+  <text x="64" y="422" class="cmd line l10">$ gaia memory summarize --subject user:preview --response-profile concise --json</text>
+  <text x="64" y="450" class="text line l11">summary_memory_id=m20260214162722-42e55a selected_source_count=2</text>
+  <text x="64" y="476" class="text line l12">response_profile=concise summary_event_id=ms20260214162722-a61fea</text>
 
-  <text x="64" y="596" class="text line l14">assistant track readiness: npm global install + OAuth onboarding + dry-run loop</text>
-  <text x="64" y="626" class="text line l15">release channel: @gaia-minds/assistant-cli@0.2.0</text>
-  <text x="64" y="666" class="cmd line l16">$ gaia onboard<tspan class="cursor">_</tspan></text>
+  <text x="64" y="522" class="cmd line l13">$ gaia traces --type feedback_record --last 1</text>
+  <text x="64" y="550" class="text line l14">2026-02-14T16:27:21Z | feedback_record | safe | ok | saved fb20260214162721-bfb4e2</text>
+
+  <rect x="64" y="586" width="1150" height="16" rx="8" class="bar-bg"/>
+  <rect x="64" y="586" width="1150" height="16" rx="8" class="bar-fill"/>
+
+  <text x="64" y="646" class="meta line l15">capabilities shown: response profiles, feedback loop capture, memory summarize, trace filters</text>
+  <text x="64" y="672" class="meta line l16">source-of-truth command mapping is documented in assistant/README.md</text>
+  <text x="64" y="698" class="meta line l17">release line remains @gaia-minds/assistant-cli@0.2.0 until #108 ships 0.3.0</text>
+  <text x="64" y="742" class="cmd line l18">$ gaia chat --response-profile auto</text>
+  <text x="64" y="770" class="text line l19">gaia&gt; I will keep updates concise and actionable.</text>
+  <text x="64" y="796" class="cmd line l20">$ gaia traces --last 5<tspan class="cursor">_</tspan></text>
 </svg>

--- a/assistant/assets/gaia-assistant-terminal.svg
+++ b/assistant/assets/gaia-assistant-terminal.svg
@@ -1,35 +1,53 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="760" viewBox="0 0 1280 760" fill="none">
-  <rect width="1280" height="760" rx="20" fill="#0B1220"/>
-  <rect x="34" y="28" width="1212" height="704" rx="16" fill="#101A2E" stroke="#2A3C64"/>
-  <rect x="34" y="28" width="1212" height="54" rx="16" fill="#172440"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="820" viewBox="0 0 1280 820" fill="none">
+  <defs>
+    <style>
+      .frame { fill: #0B1220; }
+      .panel { fill: #101A2E; stroke: #2A3C64; }
+      .titlebar { fill: #172440; }
+      .title { fill: #D8E5FF; font-size: 20px; font-family: monospace; }
+      .cmd { fill: #8CE99A; font-size: 19px; font-family: monospace; }
+      .ok { fill: #8CE99A; font-size: 17px; font-family: monospace; }
+      .warn { fill: #F7D070; font-size: 17px; font-family: monospace; }
+      .text { fill: #CBD9F8; font-size: 17px; font-family: monospace; }
+      .meta { fill: #9AB6E9; font-size: 16px; font-family: monospace; }
+    </style>
+  </defs>
+
+  <rect class="frame" width="1280" height="820" rx="20"/>
+  <rect class="panel" x="34" y="28" width="1212" height="764" rx="16"/>
+  <rect class="titlebar" x="34" y="28" width="1212" height="54" rx="16"/>
   <circle cx="72" cy="55" r="8" fill="#FF5F57"/>
   <circle cx="100" cy="55" r="8" fill="#FEBC2E"/>
   <circle cx="128" cy="55" r="8" fill="#28C840"/>
-  <text x="160" y="62" fill="#D8E5FF" font-size="20" font-family="monospace">gaia-assistant live preview (npm global CLI)</text>
+  <text x="160" y="62" class="title">gaia assistant live preview (current CLI capability surfaces)</text>
 
-  <text x="64" y="126" fill="#8CE99A" font-size="20" font-family="monospace">$ npm install -g @gaia-minds/assistant-cli</text>
-  <text x="64" y="156" fill="#CBD9F8" font-size="18" font-family="monospace">changed 1 package in 261ms</text>
+  <text x="64" y="122" class="cmd">$ gaia doctor</text>
+  <text x="64" y="150" class="ok">[ok]</text>
+  <text x="118" y="150" class="text">required command found: python3</text>
+  <text x="64" y="176" class="ok">[ok]</text>
+  <text x="118" y="176" class="text">optional command found: codex</text>
+  <text x="64" y="202" class="warn">[warn]</text>
+  <text x="136" y="202" class="text">launcher config not found yet - run `gaia init` or `gaia onboard`</text>
 
-  <text x="64" y="202" fill="#8CE99A" font-size="20" font-family="monospace">$ GAIA_ASSISTANT_HOME=/tmp/gaia-assistant-demo gaia doctor</text>
-  <text x="64" y="232" fill="#CBD9F8" font-size="18" font-family="monospace">Gaia assistant doctor</text>
-  <text x="64" y="258" fill="#8CE99A" font-size="18" font-family="monospace">[ok]</text>
-  <text x="118" y="258" fill="#CBD9F8" font-size="18" font-family="monospace">required command found: python3</text>
-  <text x="64" y="284" fill="#8CE99A" font-size="18" font-family="monospace">[ok]</text>
-  <text x="118" y="284" fill="#CBD9F8" font-size="18" font-family="monospace">required command found: git</text>
-  <text x="64" y="310" fill="#F7D070" font-size="18" font-family="monospace">[warn]</text>
-  <text x="136" y="310" fill="#CBD9F8" font-size="18" font-family="monospace">no linked OAuth profile in launcher config</text>
-  <text x="64" y="336" fill="#CBD9F8" font-size="18" font-family="monospace">run `gaia onboard`</text>
+  <text x="64" y="248" class="cmd">$ gaia chat --response-profile concise</text>
+  <text x="64" y="276" class="text">Started session: s20260214162721-fe6476</text>
+  <text x="64" y="302" class="text">Response profile: concise (override)</text>
+  <text x="64" y="328" class="text">gaia&gt; [local-openai][profile=concise] Need concise updates</text>
 
-  <text x="64" y="386" fill="#8CE99A" font-size="20" font-family="monospace">$ GAIA_ASSISTANT_HOME=/tmp/gaia-assistant-demo gaia run --mode single --dry-run</text>
-  <text x="64" y="416" fill="#CBD9F8" font-size="18" font-family="monospace">17:02:14 [INFO] Loaded config: gaia-agent v0.1.0</text>
-  <text x="64" y="442" fill="#CBD9F8" font-size="18" font-family="monospace">17:02:14 [INFO] Active track: assistant (service=80%, self_improvement=20%)</text>
-  <text x="64" y="468" fill="#CBD9F8" font-size="18" font-family="monospace">17:02:14 [INFO] No actions proposed this cycle.</text>
-  <text x="64" y="494" fill="#8CE99A" font-size="18" font-family="monospace">17:02:14 [INFO] Cycle 1 complete: 0 succeeded, 0 failed</text>
-  <text x="64" y="520" fill="#CBD9F8" font-size="18" font-family="monospace">Running Gaia assistant in single mode</text>
+  <text x="64" y="374" class="cmd">$ gaia feedback record --label not-helpful --session-id &lt;session&gt; --trace-id &lt;trace&gt;</text>
+  <text x="64" y="402" class="text">feedback_id=fb20260214162721-bfb4e2 label=not-helpful session+trace linked</text>
 
-  <rect x="64" y="560" width="1150" height="138" rx="12" fill="#0D1628" stroke="#33507E"/>
-  <text x="88" y="598" fill="#C3D6FF" font-size="20" font-family="monospace">Current status</text>
-  <text x="88" y="630" fill="#D8E5FF" font-size="18" font-family="monospace">- npm package is live: @gaia-minds/assistant-cli@0.2.0</text>
-  <text x="88" y="658" fill="#D8E5FF" font-size="18" font-family="monospace">- Global gaia CLI runs doctor/onboard/run without repository checkout</text>
-  <text x="88" y="686" fill="#8CE99A" font-size="20" font-family="monospace">$ gaia onboard</text>
+  <text x="64" y="448" class="cmd">$ gaia memory summarize --subject user:preview --response-profile concise --json</text>
+  <text x="64" y="476" class="text">summary_memory_id=m20260214162722-42e55a selected_source_count=2</text>
+  <text x="64" y="502" class="text">response_profile=concise summary_event_id=ms20260214162722-a61fea</text>
+
+  <text x="64" y="548" class="cmd">$ gaia traces --type feedback_record --last 1</text>
+  <text x="64" y="576" class="text">2026-02-14T16:27:21Z | feedback_record | safe | ok | saved fb20260214162721-bfb4e2</text>
+
+  <rect x="64" y="616" width="1150" height="148" rx="12" fill="#0D1628" stroke="#33507E"/>
+  <text x="88" y="652" class="title">Capability coverage shown</text>
+  <text x="88" y="680" class="meta">- chat response profiles (auto/concise/balanced/detailed)</text>
+  <text x="88" y="706" class="meta">- deterministic feedback capture (`gaia feedback record/list`) with session + trace linkage</text>
+  <text x="88" y="732" class="meta">- memory summarize workflow (`gaia memory summarize`) with source-count metadata</text>
+  <text x="88" y="758" class="meta">- trace inspection for governance/audit (`gaia traces` filters)</text>
 </svg>


### PR DESCRIPTION
## Summary
- Refreshed live-preview assets to match current Gaia CLI surfaces:
  - `assistant/assets/gaia-assistant-terminal.svg`
  - `assistant/assets/gaia-assistant-demo-animated.svg`
- Updated README captions/status bullets for current capabilities (response profiles, feedback capture, memory summarize, trace filters).
- Added a source-of-truth freshness note in `assistant/README.md` mapping asset files to the command capture flow used.
- Synced sprint/state docs for lane delivery (`STATUS.md`, `ROADMAP.md`, `CHANGELOG.md`).

## Track Declaration
- [x] `assistant-track`
- [ ] `framework-track`
- [ ] Cross-track (`assistant-track` + `framework-track`)

## Risk Level
- [x] Low
- [ ] Medium
- [ ] High (requires explicit maintainer review before merge)

## Self-Evolution Applicability
- [ ] Applies: this PR changes self-evolution behavior/governance.
- [x] Not applicable: no self-evolution behavior/governance changes.

## Self-Evolution Evidence (required when applicability is "Applies")
- Baseline evidence: N/A
- Delta observed: N/A
- Thresholds and guardrails: N/A
- Rollback/fallback: N/A
- Risk notes: N/A

## Validation
- [x] `make check-all`
- [ ] `make test-smoke` (if assistant/runtime behavior changed)
- [ ] `make test-uat` (required for assistant feature changes)
- [x] Additional targeted checks documented below

Additional targeted checks:
- XML parse validation for updated assets:
  - `python3 - <<'PY' ... ET.parse('assistant/assets/gaia-assistant-terminal.svg') ... ET.parse('assistant/assets/gaia-assistant-demo-animated.svg') ... PY`
- `make generate-indexes`

## Checklist
- [x] Changes are small, safe, and incremental
- [x] No breaking changes to structure or website
- [x] Docs follow repo markdown standards
- [x] Links added/updated were verified
- [x] Track and risk are declared
- [x] Self-evolution applicability declared and rubric completed when required
- [x] Handoff notes included (files changed, validations, follow-ups)
- [ ] New feature surfaces include UAT updates in this PR

## UAT Change Justification
- Not applicable. No runtime feature surface changed.

## Notes
- Main role: `contributor`
- Sub-roles used: `gaia-technical-writer`, `gaia-qa-evaluator`
- Local doc verification in `make check-all` passed; environment does not have `markdownlint-cli2`/`lychee` installed, so those checks were skipped by the existing validator script.
- This closes the stabilization docs/asset lane and leaves `#108` as the next dependency item.

Closes #107
