### PR TITLE
feat(framework): integrate unmet-intent signals into hypothesis candidate generation (#113)

### DIFF
--- a/.github/workflows/hypothesis-pipeline.yml
+++ b/.github/workflows/hypothesis-pipeline.yml
@@ -91,6 +91,9 @@ jobs:
           print("failure fixture validated: rollback recommendation required=true and canary decision=rollback-required")
           PY
 
+      - name: Validate signal-derived candidate generation fixture
+        run: make hypothesis-signals-candidate-fixture
+
       - name: Upload hypothesis artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Validation-aware skill matching and security-gate evidence in triage output (`rationale`, `follow_up_action`, `security_gate`, `matched_skill`, `class_summary`) with blocked paths for dangerous intents, forbidden capabilities, or failed validation evidence (`tools/gaia-assistant.py`, `#112`)
 - Deterministic triage fixture matrix + reusable check harness (`assistant/signal-triage-fixtures.json`, `tools/signal-triage-check.sh`) with smoke/UAT coverage and feature-governance mappings (`tools/smoke-test.sh`, `assistant/uat-scenarios.json`, `assistant/feature-catalog.json`, `#112`)
 - UAT governance change record for unmet-intent triage command-surface coverage (`docs/uat-changes/2026-02-14-signals-triage-surface.md`, `#112`)
+- Signal-derived hypothesis candidate generation flow in hypothesis pipeline (`tools/hypothesis-pipeline.py` `signals-candidates`) with deterministic threshold routing (`promote|hold|reject`) and triage-aware promotion classes (`#113`)
+- Opt-out and retention-window candidate controls honoring `signals.enabled` plus effective retention bounds, with derived-signal-only rejection for forbidden raw-text key classes (`#113`)
+- Optional promoted candidate hypothesis stub emission for downstream canary-gated pipeline use (`assistant/hypotheses/generated/*.json` via `--emit-hypotheses-dir`) (`#113`)
+- Deterministic signal-candidate fixture matrix + reusable check harness (`assistant/hypothesis-signal-candidate-fixtures.json`, `tools/hypothesis-signal-candidate-check.sh`, `make hypothesis-signals-candidate-fixture`) (`#113`)
+- Hypothesis pipeline CI coverage extension for signal-derived candidate generation fixture (`.github/workflows/hypothesis-pipeline.yml`, `#113`)
 - Skill provenance admission policy controls for validation workflow (`skills_provenance_mode`, `skills_attestation_mode`, `skills_source_health_mode`, `skills_source_health_min_score`) (`tools/gaia-assistant.py`, `#122`)
 - Deterministic provenance admission evidence in skill validation reports (`provenance_admission`) and `skills_validate` trace metadata (`tools/gaia-assistant.py`, `#122`)
 - Provenance fixture set for skill validation quality checks (`assistant/fixtures/skills/provenance-complete/*`, `assistant/fixtures/skills/provenance-missing/SKILL.md`, `assistant/fixtures/skills/manifest.json`, `#122`)
@@ -33,10 +38,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Follow-on hardening issue set seeded from `#115`: provenance admission gate (`#122`) and obfuscation-aware validator/fixture expansion (`#123`)
 
 ### Changed
+- Top-level roadmap/status state now marks `#113` delivered and the signal-driven follow-on queue complete pending next planning round (`STATUS.md`, `ROADMAP.md`)
 - Top-level roadmap/status state now marks `#123` delivered and advances signal-driven queue sequencing with `#112` triage delivery evidence (`STATUS.md`, `ROADMAP.md`)
 - Top-level roadmap/status state now marks `#122` delivered and advances active queue ownership to `#123` (`STATUS.md`, `ROADMAP.md`)
 - UAT policy checker now enforces command-path coverage across both assistant CLI sources after parser modularization (`tools/gaia-assistant.py` + `tools/gaia_assistant_parser.py`) (`tools/check-uat-policy.py`, `assistant/uat-policy.md`)
 - Assistant/runtime architecture docs now include unmet-intent skill-first triage behavior, triage artifact paths, and command usage updates (`README.md`, `assistant/README.md`, `infrastructure/architecture.md`, `#112`)
+- Hypothesis pipeline contract/docs now include signal-derived candidate integration, threshold semantics, and derived-signal-only guardrails (`assistant/README.md`, `assistant/hypotheses/README.md`, `infrastructure/hypothesis-pipeline-v1.md`, `infrastructure/architecture.md`, `#113`)
 
 ### Removed
 - _Nothing yet._

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs-check verify-resources generate-indexes check-indexes check-all test-smoke test-uat uat-policy quality-matrix compatibility-matrix benchmark memory-benchmark memory-summary-benchmark memory-quality benchmark-trend hypothesis-validate hypothesis-run hypothesis-dry-run hypothesis-hold-fixture hypothesis-failure-fixture token-budget-fixtures reliability-checkpoint reliability-checkpoint-check reliability-checkpoint-simulate-breach reliability-drift reliability-drift-check reliability-drift-simulate hardening-phase1 install-hooks uninstall-hooks assistant-init assistant-onboard assistant-auth-status assistant-doctor assistant-run-dry
+.PHONY: docs-check verify-resources generate-indexes check-indexes check-all test-smoke test-uat uat-policy quality-matrix compatibility-matrix benchmark memory-benchmark memory-summary-benchmark memory-quality benchmark-trend hypothesis-validate hypothesis-run hypothesis-dry-run hypothesis-hold-fixture hypothesis-failure-fixture hypothesis-signals-candidate-fixture token-budget-fixtures reliability-checkpoint reliability-checkpoint-check reliability-checkpoint-simulate-breach reliability-drift reliability-drift-check reliability-drift-simulate hardening-phase1 install-hooks uninstall-hooks assistant-init assistant-onboard assistant-auth-status assistant-doctor assistant-run-dry
 
 HYPOTHESIS_OUTPUT_ROOT ?= /tmp/gaia-hypothesis-evals
 RELIABILITY_CHECKPOINT_ROOT ?= /tmp/gaia-reliability-checkpoints
@@ -64,6 +64,9 @@ hypothesis-hold-fixture:
 
 hypothesis-failure-fixture:
 	python3 ./tools/hypothesis-pipeline.py run --hypothesis ./assistant/hypotheses/phase3-hypothesis-pipeline-v1-failure-fixture.json --output-root "$(HYPOTHESIS_OUTPUT_ROOT)" --run-id failure-fixture --dry-run
+
+hypothesis-signals-candidate-fixture:
+	bash ./tools/hypothesis-signal-candidate-check.sh
 
 token-budget-fixtures:
 	python3 ./tools/token-budget-fixtures.py --fixtures ./assistant/token-budget-fixtures.json --json-out "$(TOKEN_BUDGET_FIXTURE_OUTPUT)" --check

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ See `assistant/README.md` for full runtime and release docs.
 - Chat supports deterministic response profiles (`auto`, `concise`, `balanced`, `detailed`) with config + override selection
 - Memory summarization supports traceable profile-aware compaction via `gaia memory summarize`
 - Unmet-intent signal runtime supports privacy-preserving derived-signal extraction + skill-first triage (`gaia signals extract/list/triage/export/clear`) with default-on collection, explicit opt-out, 90-day retention, bounded local storage, and security-gated import-candidate routing
+- Hypothesis pipeline integrates derived signal+triage aggregates into deterministic candidate generation (`tools/hypothesis-pipeline.py signals-candidates`) with threshold gating, opt-out enforcement, and derived-signal-only redaction guards
 - Skills validation includes provenance admission controls for broad-source imports (`skills_provenance_mode`, `skills_attestation_mode`, `skills_source_health_mode`) with deterministic pass/warn/fail evidence in validation reports
 - Skills validation includes obfuscation-aware static analysis for encoded/hidden/split-token prompt-injection and sensitive-exfiltration directives, with detection-stage metadata in reports for explainability
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -196,7 +196,7 @@ Execution queue (post-delivery stabilization round):
 
 Recommended merge order:
 
-1. Stabilization round complete; signal-driven follow-on queue now proceeds with `#113` after delivery of `#111`, `#112`, `#115`, `#122`, and `#123`.
+1. Stabilization round complete; signal-driven follow-on queue is delivered (`#111`, `#112`, `#113`, `#115`, `#122`, `#123`).
 2. Continue folding security-research updates from `#115` into periodic skill-validation policy hardening as the queue advances.
 
 Execution queue (signal-driven self-evolution follow-on; planning published):
@@ -206,12 +206,12 @@ Execution queue (signal-driven self-evolution follow-on; planning published):
 - `#115` Continuous security validation research for broad-source skill imports (delivered)
 - `#122` Provenance admission gate for broad-source skill imports (delivered)
 - `#112` Skill-first triage for unmet-intent signals (`existing-skill-enable` / `skill-import-candidate` / `core-feature-gap`) with broad-source import candidates gated by security validation (delivered)
-- `#113` Integrate unmet-intent signal aggregates into hypothesis candidate generation
+- `#113` Integrate unmet-intent signal aggregates into hypothesis candidate generation (delivered)
 - `#123` Obfuscation-aware skill validation hardening for prompt-injection patterns (seeded by `#115`; supports `#112`) (delivered)
 
 Recommended merge order:
 
-1. `#113` (depends on delivered `#111` + `#112` signal-triage artifacts)
+1. Queue delivered; next planning round should seed the next framework-evolution lane set.
 
 Privacy/architecture rule for this queue:
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -50,7 +50,8 @@ See `ROADMAP.md` for full phase details and exit criteria.
 - `Phase 3 Skill-Import Security Research` - continuous security-validation synthesis for broad-source skill imports with execution-ready hardening lanes seeded (`#115`, PR `#124`)
 - `Phase 3 Skill Provenance Admission Gate` - deterministic source pin/attestation/source-health policy checks for `gaia skills validate` with pass/warn/fail regression coverage (`#122`, PR `#125`)
 - `Phase 3 Obfuscation-Aware Skill Validation Hardening` - canonicalization-aware blocking for encoded/hidden/split-token prompt-injection and sensitive-exfiltration payloads with deterministic fixture/smoke/UAT coverage (`#123`, PR `#126`)
-- `Phase 3 Skill-First Unmet-Intent Triage` - deterministic `gaia signals triage` classification (`existing-skill-enable` / `skill-import-candidate` / `core-feature-gap` / `out-of-scope-or-rejected`) with security-gated import-candidate routing and validation-aware skill enablement (`#112`, PR pending)
+- `Phase 3 Skill-First Unmet-Intent Triage` - deterministic `gaia signals triage` classification (`existing-skill-enable` / `skill-import-candidate` / `core-feature-gap` / `out-of-scope-or-rejected`) with security-gated import-candidate routing and validation-aware skill enablement (`#112`, PR `#127`)
+- `Phase 3 Signal-Derived Hypothesis Candidate Integration` - deterministic signal+triage threshold routing into hypothesis candidate artifacts with opt-out enforcement, derived-signal-only guardrails, and promoted candidate stub generation for canary-gated hypothesis pipeline flow (`#113`, PR pending)
 
 ## In Progress
 
@@ -58,11 +59,11 @@ _Nothing currently in progress._
 
 ## Next Up (Post-Phase-3 Delivery Queue)
 
-_Signal-driven follow-on queue continues with `#113` after `#112` merge._
+_No queued signal-driven follow-on lanes. Awaiting next planning round._
 
 ## Planned Next Wave (Signal-Driven Evolution Follow-On)
 
-- `#113` `[Phase 3][Framework]` Integrate unmet-intent signals into hypothesis candidate generation (depends on `#111` + `#112`)
+_No queued items._
 
 ## Blocked
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -229,6 +229,9 @@ make hypothesis-hold-fixture
 
 # run failure fixture (expected non-zero, includes rollback recommendation)
 make hypothesis-failure-fixture
+
+# run signal-derived candidate generation fixture checks
+make hypothesis-signals-candidate-fixture
 ```
 
 Artifacts:
@@ -237,10 +240,22 @@ Artifacts:
 - Pipeline tool: `tools/hypothesis-pipeline.py`
 - Evidence output: `assistant/hypothesis-evals/<hypothesis-id>/<run-id>/`
 - Canary decision evidence: `evaluation-report.json` -> `canary_decision` (`go` | `hold` | `rollback-required`)
+- Signal-derived candidate artifact: `assistant/hypotheses/signal-candidates.json`
 - Contract docs: `infrastructure/hypothesis-pipeline-v1.md`
 
 `make hypothesis-*` commands write to `/tmp/gaia-hypothesis-evals` by default.
 Override with `HYPOTHESIS_OUTPUT_ROOT=<path>` if you want repo-local artifacts.
+
+Candidate generation command:
+
+```bash
+python3 tools/hypothesis-pipeline.py signals-candidates \
+  --signals-ledger ~/.gaia-assistant/data/unmet-intent-signals.json \
+  --triage-ledger ~/.gaia-assistant/data/unmet-intent-signal-triage.json \
+  --output assistant/hypotheses/signal-candidates.json \
+  --emit-hypotheses-dir assistant/hypotheses/generated \
+  --json
+```
 
 ## Reliability Checkpoint (Phase 3)
 

--- a/assistant/hypotheses/README.md
+++ b/assistant/hypotheses/README.md
@@ -11,6 +11,9 @@ This folder stores versioned Phase 3 hypothesis proposal artifacts consumed by
   deterministic hold-decision fixture for canary sample insufficiency path.
 - `phase3-hypothesis-pipeline-v1-failure-fixture.json`:
   deterministic failure fixture for rollback recommendation validation.
+- `signal-candidates.json`:
+  generated candidate artifact mapping derived unmet-intent + triage signals to
+  hypothesis proposal stubs.
 
 ## Commands
 
@@ -46,6 +49,23 @@ python3 tools/hypothesis-pipeline.py run \
   --hypothesis assistant/hypotheses/phase3-hypothesis-pipeline-v1-hold-fixture.json \
   --run-id hold-fixture \
   --dry-run
+```
+
+Generate signal-derived hypothesis candidates (derived-signal-only, thresholded):
+
+```bash
+python3 tools/hypothesis-pipeline.py signals-candidates \
+  --signals-ledger ~/.gaia-assistant/data/unmet-intent-signals.json \
+  --triage-ledger ~/.gaia-assistant/data/unmet-intent-signal-triage.json \
+  --output assistant/hypotheses/signal-candidates.json \
+  --emit-hypotheses-dir assistant/hypotheses/generated \
+  --json
+```
+
+Run deterministic candidate-generation fixture checks:
+
+```bash
+make hypothesis-signals-candidate-fixture
 ```
 
 Generated evidence artifacts are written under:

--- a/assistant/hypothesis-signal-candidate-fixtures.json
+++ b/assistant/hypothesis-signal-candidate-fixtures.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": 1,
+  "suite": "gaia-hypothesis-signal-candidates",
+  "now": "2026-02-14T00:00:00+00:00",
+  "thresholds": {
+    "min_count": 2,
+    "min_confidence": 0.65,
+    "max_age_days": 90,
+    "max_candidates": 10
+  },
+  "signals_ledger": {
+    "schema_version": 1,
+    "generated_at": "2026-02-14T00:00:00+00:00",
+    "collection_enabled": true,
+    "retention_days": 90,
+    "max_records": 300,
+    "signal_count": 5,
+    "signals": [
+      {
+        "signal_id": "sig-promote",
+        "signal_type": "feedback_correction_pattern",
+        "intent_tag": "response_quality.concise_bullets",
+        "confidence": 0.82,
+        "count": 5,
+        "first_seen_at": "2026-02-10T00:00:00+00:00",
+        "last_seen_at": "2026-02-13T20:00:00+00:00",
+        "source_event_count": 7
+      },
+      {
+        "signal_id": "sig-hold-confidence",
+        "signal_type": "command_failure",
+        "intent_tag": "command.workflow_automation_gap",
+        "confidence": 0.44,
+        "count": 6,
+        "first_seen_at": "2026-02-10T00:00:00+00:00",
+        "last_seen_at": "2026-02-13T20:00:00+00:00",
+        "source_event_count": 6
+      },
+      {
+        "signal_id": "sig-hold-recency",
+        "signal_type": "command_failure",
+        "intent_tag": "skills.enable_existing_reader",
+        "confidence": 0.78,
+        "count": 4,
+        "first_seen_at": "2025-08-01T00:00:00+00:00",
+        "last_seen_at": "2025-08-01T00:00:00+00:00",
+        "source_event_count": 4
+      },
+      {
+        "signal_id": "sig-reject-class",
+        "signal_type": "command_failure",
+        "intent_tag": "skills.unsafe_payload_attempt",
+        "confidence": 0.91,
+        "count": 9,
+        "first_seen_at": "2026-02-12T00:00:00+00:00",
+        "last_seen_at": "2026-02-13T22:00:00+00:00",
+        "source_event_count": 10
+      },
+      {
+        "signal_id": "sig-redaction-block",
+        "signal_type": "command_failure",
+        "intent_tag": "command.pipeline_builder_needed",
+        "confidence": 0.88,
+        "count": 5,
+        "first_seen_at": "2026-02-12T00:00:00+00:00",
+        "last_seen_at": "2026-02-13T22:00:00+00:00",
+        "source_event_count": 5,
+        "raw_text": "THIS_SHOULD_NEVER_BE_ALLOWED"
+      }
+    ]
+  },
+  "triage_ledger": {
+    "schema_version": 1,
+    "generated_at": "2026-02-14T00:00:00+00:00",
+    "source_signal_count": 5,
+    "triage_count": 5,
+    "class_summary": {
+      "existing-skill-enable": 1,
+      "skill-import-candidate": 2,
+      "core-feature-gap": 1,
+      "out-of-scope-or-rejected": 1
+    },
+    "items": [
+      {
+        "signal_id": "sig-promote",
+        "triage_class": "core-feature-gap",
+        "triage_confidence": 0.88,
+        "follow_up_action": "open_core_feature_followup"
+      },
+      {
+        "signal_id": "sig-hold-confidence",
+        "triage_class": "skill-import-candidate",
+        "triage_confidence": 0.63,
+        "follow_up_action": "source_and_validate_skill_candidate"
+      },
+      {
+        "signal_id": "sig-hold-recency",
+        "triage_class": "existing-skill-enable",
+        "triage_confidence": 0.74,
+        "follow_up_action": "enable_skill:local:reader"
+      },
+      {
+        "signal_id": "sig-reject-class",
+        "triage_class": "out-of-scope-or-rejected",
+        "triage_confidence": 0.95,
+        "follow_up_action": "reject_unsafe_request"
+      },
+      {
+        "signal_id": "sig-redaction-block",
+        "triage_class": "skill-import-candidate",
+        "triage_confidence": 0.81,
+        "follow_up_action": "source_and_validate_skill_candidate"
+      }
+    ]
+  },
+  "expectations": {
+    "status_by_signal": {
+      "sig-promote": "promote",
+      "sig-hold-confidence": "hold",
+      "sig-hold-recency": "hold",
+      "sig-reject-class": "reject",
+      "sig-redaction-block": "reject"
+    },
+    "promoted_signal_ids": [
+      "sig-promote"
+    ],
+    "promoted_count": 1,
+    "held_count": 2,
+    "rejected_count": 2,
+    "opt_out_promoted_count": 0
+  }
+}

--- a/infrastructure/INDEX.md
+++ b/infrastructure/INDEX.md
@@ -21,9 +21,11 @@ Technical foundations and operational guidance.
 - [Post-Phase-2 Reassessment Planning Round - 2026-02-13](planning-round-2026-02-13-post-phase2-reassessment.md) — Updated: February 13, 2026 Coordinator: Codex (planner main role) Activated sub-roles: `gaia-integration-coordinator`, `gaia-technical-writer`...
 - [Post-Phase-3-Delivery Stabilization + Release Planning Round - 2026-02-14](planning-round-2026-02-14-post-phase3-delivery-stabilization.md) — Updated: February 14, 2026 Coordinator: Codex (planner main role) Activated sub-roles: `gaia-planner`, `gaia-researcher`...
 - [Post-Phase-3-Kickoff Reassessment Planning Round - 2026-02-13](planning-round-2026-02-13-post-phase3-kickoff-reassessment.md) — Updated: February 13, 2026 Coordinator: Codex (planner main role) Activated sub-roles: `gaia-planner`, `gaia-integration-coordinator`...
+- [Privacy and Memory Review](privacy-memory-review-2026-02-14-signal-hypothesis-candidates.md) — Updated: 2026-02-14
 - [Privacy and Memory Review - Unmet-Intent Signals (2026-02-14)](privacy-memory-review-2026-02-14-unmet-intent-signals.md) — 1. Scope
 - [Privacy and Memory Review Template](privacy-memory-review-template.md) — Updated: February 8, 2026
 - [QA Evaluation - Unmet-Intent Signals (2026-02-14)](qa-evaluation-2026-02-14-unmet-intent-signals.md) — 1. Evaluation Scope
+- [QA Evaluation Report](qa-evaluation-2026-02-14-signal-hypothesis-candidates.md) — Updated: 2026-02-14
 - [QA Evaluation Report](qa-evaluation-2026-02-14-signals-skill-triage.md) — Updated: 2026-02-14
 - [QA Evaluation Report](qa-evaluation-2026-02-14-skill-provenance-admission.md) — Updated: 2026-02-14
 - [QA Evaluation Report](qa-evaluation-2026-02-14-skills-obfuscation-hardening.md) — Updated: 2026-02-14

--- a/infrastructure/architecture.md
+++ b/infrastructure/architecture.md
@@ -977,6 +977,60 @@ Lane: `Skill-first triage for unmet-intent signals` (`#112`)
 - Updated UAT feature-governance mapping:
   - `signals triage`
 
+## Phase 3 Delta: Signal-Derived Hypothesis Candidate Integration (2026-02-14)
+
+Lane: `Integrate unmet-intent signals into hypothesis candidate generation`
+(`#113`)
+
+### Runtime integration surface
+
+- Extended `tools/hypothesis-pipeline.py` with:
+  - `signals-candidates`
+- Candidate generation consumes only derived local artifacts:
+  - `~/.gaia-assistant/data/unmet-intent-signals.json`
+  - `~/.gaia-assistant/data/unmet-intent-signal-triage.json`
+- Generated candidate artifact path (repo-local default):
+  - `assistant/hypotheses/signal-candidates.json`
+- Optional promoted hypothesis stub emission:
+  - `assistant/hypotheses/generated/*.json`
+
+### Candidate contract and thresholds
+
+- Deterministic candidate status model:
+  - `promote`
+  - `hold`
+  - `reject`
+- Promotion is allowed only for triage classes:
+  - `existing-skill-enable`
+  - `skill-import-candidate`
+  - `core-feature-gap`
+- Deterministic promotion gates:
+  - minimum signal count
+  - minimum confidence
+  - recency bound (`age_days`) constrained by effective retention window
+  - maximum candidate cap
+
+### Privacy and governance guardrails
+
+- Opt-out enforcement:
+  - if `signals.enabled=false`, candidate generation is suggestion-only with no
+    promoted candidates.
+- Derived-signal-only enforcement:
+  - forbidden raw-text key classes (`raw_text`, `transcript`, `messages`,
+    etc.) cause candidate rejection.
+- Promoted stubs remain gate-controlled by existing hypothesis pipeline canary
+  and rollback evidence contracts (`go|hold|rollback-required` remains unchanged
+  in evaluation path).
+
+### Deterministic quality coverage
+
+- Added candidate-generation fixture matrix:
+  - `assistant/hypothesis-signal-candidate-fixtures.json`
+- Added reusable deterministic candidate check harness:
+  - `tools/hypothesis-signal-candidate-check.sh`
+- Added CI fixture step in hypothesis workflow:
+  - `.github/workflows/hypothesis-pipeline.yml`
+
 ## Phase 3 Delta: Skill Provenance Admission Gate (2026-02-14)
 
 Lane: `Provenance admission gate for broad-source skill imports` (`#122`)

--- a/infrastructure/hypothesis-pipeline-v1.md
+++ b/infrastructure/hypothesis-pipeline-v1.md
@@ -13,6 +13,7 @@ Define the first operational self-evolution hypothesis pipeline:
 1. proposal artifact
 2. deterministic evaluation run
 3. PR-ready evidence package
+4. derived-signal candidate generation (thresholded, suggestion-mode)
 
 This contract is rollout-focused governance tooling only. It does not perform
 automatic merge or deployment.
@@ -97,6 +98,9 @@ Subcommands:
 - `validate`: validate hypothesis contract
 - `run`: execute deterministic evaluation and generate evidence package
 - `package`: regenerate evidence markdown from an existing report
+- `signals-candidates`: build thresholded hypothesis candidates from
+  `unmet-intent-signals.json` + `unmet-intent-signal-triage.json` with
+  derived-signal-only guardrails
 
 Default output root:
 
@@ -109,6 +113,9 @@ Generated artifacts:
 - `commands/*.stderr.log`
 - `evaluation-report.json`
 - `evidence-bundle.md`
+- `assistant/hypotheses/signal-candidates.json` (generated candidate summary)
+- optional promoted candidate hypothesis stubs under
+  `assistant/hypotheses/generated/*.json`
 
 ## Determinism + Failure Behavior
 
@@ -116,6 +123,20 @@ Generated artifacts:
 - Evidence bundle format is stable and PR-review friendly.
 - Any required command failure, required artifact miss, or required metric gate
   failure sets report status to `fail`.
+- Signal-derived candidate generation remains suggestion-only:
+  - candidates are `promote|hold|reject`
+  - opt-out state (`signals.enabled=false`) forces `hold` (no promotion)
+  - only triage classes `existing-skill-enable`, `skill-import-candidate`, and
+    `core-feature-gap` are promotable
+  - `out-of-scope-or-rejected` remains non-promotable
+- Candidate promotion thresholds are deterministic:
+  - minimum signal `count`
+  - minimum signal `confidence`
+  - maximum `age_days` bounded by effective retention window (<= 90 days by
+    default policy)
+- Derived-signal-only policy guard:
+  - payloads containing forbidden raw-text key classes (`raw_text`,
+    `transcript`, `messages`, etc.) are rejected from promotion.
 - `evaluation-report.json` always includes explicit rollback recommendation:
   - `rollback_recommendation.required`
   - `rollback_recommendation.reason`
@@ -142,5 +163,7 @@ Generated artifacts:
   `assistant/hypotheses/phase3-hypothesis-pipeline-v1-failure-fixture.json`
 - Hold fixture:
   `assistant/hypotheses/phase3-hypothesis-pipeline-v1-hold-fixture.json`
+- Signal-candidate fixture:
+  `assistant/hypothesis-signal-candidate-fixtures.json`
 - Usage notes:
   `assistant/hypotheses/README.md`

--- a/infrastructure/privacy-memory-review-2026-02-14-signal-hypothesis-candidates.md
+++ b/infrastructure/privacy-memory-review-2026-02-14-signal-hypothesis-candidates.md
@@ -1,0 +1,68 @@
+# Privacy and Memory Review
+
+Updated: 2026-02-14
+
+## 1. Scope
+
+- Lane: `#113` Integrate unmet-intent signals into hypothesis candidate
+  generation
+- Reviewer: `@TonyThePredictor / Codex` (`gaia-privacy-memory-steward` sub-role)
+- Components reviewed:
+  - `tools/hypothesis-pipeline.py` (`signals-candidates` subcommand)
+  - `assistant/hypothesis-signal-candidate-fixtures.json`
+  - `tools/hypothesis-signal-candidate-check.sh`
+  - hypothesis workflow/contract docs updates
+
+## 2. Data Classification and Sources
+
+- Inputs used for candidate generation:
+  - derived unmet-intent signal ledger (`unmet-intent-signals.json`)
+  - derived signal triage ledger (`unmet-intent-signal-triage.json`)
+  - local config (`signals.enabled`, retention settings)
+- Prohibited input class:
+  - raw conversation transcript content
+  - free-form correction text payloads
+- Candidate artifacts include only derived summary fields:
+  - signal id/type/tag
+  - counts/confidence/recency
+  - triage class/confidence/follow-up action
+  - threshold gate pass/fail evidence
+
+## 3. Privacy Guardrails
+
+- Opt-out control enforced:
+  - if `signals.enabled=false`, candidate promotion is disabled (`hold` mode).
+- Retention-window guard enforced:
+  - candidate recency gates are bounded by effective retention window and remain
+    within default 90-day policy unless user lowers retention.
+- Raw-content rejection guard enforced:
+  - forbidden raw-text key classes (`raw_text`, `transcript`, `messages`,
+    `content`, etc.) reject candidate promotion.
+- No network export:
+  - command writes local artifacts only.
+
+## 4. Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Raw text accidentally enters source ledgers | Privacy boundary breach in candidate artifact | Forbidden-key detection rejects promotion and surfaces explicit reason |
+| Opt-out ignored in candidate generation | Policy violation | Config + ledger collection flags are both required for promotion |
+| Long-tail stale signals drive candidate noise | Low-quality self-evolution suggestions | Deterministic recency threshold bounded by retention window |
+
+## 5. Verification
+
+- `make hypothesis-signals-candidate-fixture`: pass
+- `python3 tools/hypothesis-pipeline.py signals-candidates ... --json` fixture
+  paths: pass
+- fixture asserts:
+  - derived-only payload keys
+  - threshold routing (`promote|hold|reject`)
+  - opt-out enforcement (`promoted_count=0` when disabled)
+  - generated promoted stubs validate under existing hypothesis contract
+
+## 6. Decision
+
+- Privacy/memory review status: approve
+- Conditions:
+  - keep candidate generation suggestion-only and gate-controlled
+  - continue expanding forbidden-key corpus as new leakage patterns emerge

--- a/infrastructure/qa-evaluation-2026-02-14-signal-hypothesis-candidates.md
+++ b/infrastructure/qa-evaluation-2026-02-14-signal-hypothesis-candidates.md
@@ -1,0 +1,46 @@
+# QA Evaluation Report
+
+Updated: 2026-02-14
+
+## 1. Evaluation Scope
+
+- Feature/lane: `#113` Integrate unmet-intent signals into hypothesis candidate
+  generation
+- Acceptance criteria source: issue `#113` + planning-round contract (`#110`)
+- Evaluator: `@TonyThePredictor / Codex` (`gaia-qa-evaluator` sub-role)
+
+## 2. Test Matrix
+
+| Scenario | Expected | Actual | Status |
+| --- | --- | --- | --- |
+| Threshold promotion path | high-confidence/recent/high-count triaged signal is promoted | fixture `sig-promote` => `promote` | Pass |
+| Low-confidence suppression | low-confidence signal remains hold | fixture `sig-hold-confidence` => `hold` | Pass |
+| Recency-window suppression | stale signal outside effective retention window remains hold | fixture `sig-hold-recency` => `hold` | Pass |
+| Non-promotable triage class | `out-of-scope-or-rejected` stays non-promotable | fixture `sig-reject-class` => `reject` | Pass |
+| Derived-only redaction guard | forbidden raw-text keys reject promotion | fixture `sig-redaction-block` => `reject` | Pass |
+| Opt-out enforcement | no promoted candidates when `signals.enabled=false` | fixture rerun returns `promoted_count=0`, `opt_out_respected=true` | Pass |
+| Hypothesis integration | promoted candidate stubs validate under pipeline contract | generated stub(s) pass `hypothesis-pipeline.py validate` | Pass |
+
+## 3. Regression Check
+
+- Baseline reference: `origin/main` at `c573dfa` (post-`#112`)
+- Regressions found: none
+- Severity: none
+
+## 4. Commands and Evidence
+
+- `python3 -m py_compile tools/hypothesis-pipeline.py`: pass
+- `bash ./tools/hypothesis-signal-candidate-check.sh`: pass
+- `make hypothesis-dry-run`: pass
+- `make hypothesis-hold-fixture`: pass
+- `make hypothesis-failure-fixture` (expected non-zero): pass
+- `make check-all`: pass
+
+## 5. Decision
+
+- Release readiness: yes
+- Blocking defects: none
+- Follow-up actions:
+  - connect promoted candidates to controlled proposal review queue UX
+  - expand deterministic fixture corpus for class-mix edge cases and retention
+    boundary transitions

--- a/tools/hypothesis-pipeline.py
+++ b/tools/hypothesis-pipeline.py
@@ -8,16 +8,43 @@ import json
 import re
 import subprocess
 import time
+from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_HYPOTHESIS = REPO_ROOT / "assistant" / "hypotheses" / "phase3-hypothesis-pipeline-v1.json"
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / "assistant" / "hypothesis-evals"
+DEFAULT_CONFIG = Path.home() / ".gaia-assistant" / "config.json"
+DEFAULT_SIGNALS_LEDGER = Path.home() / ".gaia-assistant" / "data" / "unmet-intent-signals.json"
+DEFAULT_SIGNALS_TRIAGE_LEDGER = Path.home() / ".gaia-assistant" / "data" / "unmet-intent-signal-triage.json"
+DEFAULT_SIGNAL_CANDIDATE_OUTPUT = REPO_ROOT / "assistant" / "hypotheses" / "signal-candidates.json"
 ALLOWED_RISK_LEVELS = {"low", "medium", "high"}
 ALLOWED_COMPARATORS = {">", ">=", "<", "<=", "==", "!="}
+SIGNAL_CANDIDATE_SCHEMA_VERSION = 1
+SIGNAL_CANDIDATE_CLASS_CHOICES: Sequence[str] = (
+    "existing-skill-enable",
+    "skill-import-candidate",
+    "core-feature-gap",
+    "out-of-scope-or-rejected",
+)
+SIGNAL_CANDIDATE_ALLOWED_PROMOTION_CLASSES: Set[str] = {
+    "existing-skill-enable",
+    "skill-import-candidate",
+    "core-feature-gap",
+}
+SIGNAL_CANDIDATE_FORBIDDEN_KEYS: Set[str] = {
+    "raw_text",
+    "transcript",
+    "conversation",
+    "messages",
+    "correction",
+    "content",
+    "user_text",
+    "prompt_text",
+}
 
 
 def _read_json(path: Path) -> Dict[str, Any]:
@@ -77,6 +104,130 @@ def _extract_json_path(payload: Dict[str, Any], json_path: str) -> Any:
             raise KeyError(f"missing key '{part}' in json_path '{json_path}'")
         cursor = cursor[part]
     return cursor
+
+
+def _read_json_optional(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    return _read_json(path)
+
+
+def _normalize_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _normalize_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+    try:
+        normalized = int(value)
+    except Exception:
+        normalized = default
+    if normalized < minimum:
+        return minimum
+    if normalized > maximum:
+        return maximum
+    return normalized
+
+
+def _safe_float(value: Any, *, default: float, minimum: float, maximum: float) -> float:
+    try:
+        normalized = float(value)
+    except Exception:
+        normalized = default
+    if normalized < minimum:
+        return minimum
+    if normalized > maximum:
+        return maximum
+    return normalized
+
+
+def _parse_iso8601(value: str) -> Optional[datetime]:
+    raw = str(value).strip()
+    if not raw:
+        return None
+    candidate = raw
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _contains_forbidden_keys(payload: Any, forbidden_keys: Set[str]) -> Optional[str]:
+    def walk(value: Any, prefix: str) -> Optional[str]:
+        if isinstance(value, dict):
+            for key, nested in value.items():
+                label = str(key).strip().lower()
+                current = f"{prefix}.{key}" if prefix else str(key)
+                if label in forbidden_keys:
+                    return current
+                found = walk(nested, current)
+                if found:
+                    return found
+        elif isinstance(value, list):
+            for idx, nested in enumerate(value):
+                current = f"{prefix}[{idx}]"
+                found = walk(nested, current)
+                if found:
+                    return found
+        return None
+
+    return walk(payload, "")
+
+
+def _signal_hypothesis_stub(
+    *,
+    base_hypothesis: Dict[str, Any],
+    signal_evidence: Dict[str, Any],
+    triage_class: str,
+) -> Dict[str, Any]:
+    signal_id = str(signal_evidence.get("signal_id", "")).strip() or "signal"
+    intent_tag = str(signal_evidence.get("intent_tag", "")).strip() or "unknown-intent"
+    count = int(signal_evidence.get("count", 0))
+    confidence = float(signal_evidence.get("confidence", 0.0))
+    hypothesis_id = f"phase3-signal-{_slug(intent_tag)}-{_slug(signal_id[-8:])}"
+
+    if triage_class == "core-feature-gap":
+        title_prefix = "Core Feature Gap"
+    elif triage_class == "skill-import-candidate":
+        title_prefix = "Skill Import Candidate"
+    else:
+        title_prefix = "Skill Activation Candidate"
+
+    stub = deepcopy(base_hypothesis)
+    stub["schema_version"] = 1
+    stub["hypothesis_id"] = hypothesis_id
+    stub["title"] = f"{title_prefix}: {intent_tag}"
+    stub["summary"] = (
+        f"Signal-derived candidate from unmet-intent evidence "
+        f"(signal_id={signal_id}, triage_class={triage_class}, count={count}, confidence={confidence:.3f})."
+    )
+    stub["owner"] = "framework-track"
+    if str(stub.get("risk_level", "")).strip().lower() not in ALLOWED_RISK_LEVELS:
+        stub["risk_level"] = "medium"
+    stub["signal_evidence"] = {
+        "source": "derived-signals-only",
+        "signal_id": signal_id,
+        "intent_tag": intent_tag,
+        "triage_class": triage_class,
+        "count": count,
+        "confidence": confidence,
+        "first_seen_at": str(signal_evidence.get("first_seen_at", "")).strip(),
+        "last_seen_at": str(signal_evidence.get("last_seen_at", "")).strip(),
+        "source_event_count": int(signal_evidence.get("source_event_count", 0)),
+    }
+    return stub
 
 
 def _resolve_template(value: str, hypothesis_id: str, output_dir: Path) -> str:
@@ -714,6 +865,224 @@ def _package_only(hypothesis_path: Path, report_path: Path, output_path: Path) -
     return 0
 
 
+def _generate_signal_candidates(
+    *,
+    signals_ledger_path: Path,
+    triage_ledger_path: Path,
+    config_path: Path,
+    output_path: Path,
+    base_hypothesis_path: Path,
+    emit_hypotheses_dir: Optional[Path],
+    min_count: int,
+    min_confidence: float,
+    max_age_days: int,
+    max_candidates: int,
+    now_value: str,
+) -> Dict[str, Any]:
+    now = _parse_iso8601(now_value) if now_value else datetime.now(timezone.utc)
+    assert now is not None
+
+    signals_payload = _read_json_optional(signals_ledger_path)
+    triage_payload = _read_json_optional(triage_ledger_path)
+    config_payload = _read_json_optional(config_path)
+    base_hypothesis = _read_json(base_hypothesis_path)
+
+    config_signals = config_payload.get("signals", {})
+    config_signals = config_signals if isinstance(config_signals, dict) else {}
+    config_enabled = _normalize_bool(config_signals.get("enabled", True), True)
+
+    ledger_enabled = _normalize_bool(signals_payload.get("collection_enabled", True), True)
+    effective_collection_enabled = config_enabled and ledger_enabled
+
+    ledger_retention_days = _normalize_int(signals_payload.get("retention_days", 90), default=90, minimum=1, maximum=365)
+    config_retention_days = _normalize_int(config_signals.get("retention_days", 90), default=90, minimum=1, maximum=365)
+    effective_window_days = min(max_age_days, ledger_retention_days, config_retention_days)
+
+    triage_items = triage_payload.get("items", [])
+    triage_items = triage_items if isinstance(triage_items, list) else []
+    triage_index: Dict[str, Dict[str, Any]] = {}
+    for item in triage_items:
+        if not isinstance(item, dict):
+            continue
+        signal_id = str(item.get("signal_id", "")).strip()
+        if not signal_id:
+            continue
+        triage_index[signal_id] = item
+
+    signals = signals_payload.get("signals", [])
+    signals = signals if isinstance(signals, list) else []
+    candidates: List[Dict[str, Any]] = []
+    promoted_hypotheses: List[str] = []
+
+    for raw_signal in signals:
+        if not isinstance(raw_signal, dict):
+            continue
+        signal_id = str(raw_signal.get("signal_id", "")).strip()
+        if not signal_id:
+            continue
+
+        triage_item = triage_index.get(signal_id, {})
+        triage_class = str(triage_item.get("triage_class", "")).strip().lower()
+        if triage_class not in SIGNAL_CANDIDATE_CLASS_CHOICES:
+            triage_class = "out-of-scope-or-rejected"
+
+        signal_evidence = {
+            "signal_id": signal_id,
+            "signal_type": str(raw_signal.get("signal_type", "")).strip().lower(),
+            "intent_tag": str(raw_signal.get("intent_tag", "")).strip(),
+            "count": _normalize_int(raw_signal.get("count", 0), default=0, minimum=0, maximum=1_000_000),
+            "confidence": round(
+                _safe_float(raw_signal.get("confidence", 0.0), default=0.0, minimum=0.0, maximum=1.0),
+                3,
+            ),
+            "first_seen_at": str(raw_signal.get("first_seen_at", "")).strip(),
+            "last_seen_at": str(raw_signal.get("last_seen_at", "")).strip(),
+            "source_event_count": _normalize_int(
+                raw_signal.get("source_event_count", 0),
+                default=0,
+                minimum=0,
+                maximum=1_000_000,
+            ),
+            "triage_class": triage_class,
+            "triage_confidence": round(
+                _safe_float(triage_item.get("triage_confidence", 0.0), default=0.0, minimum=0.0, maximum=1.0),
+                3,
+            ),
+            "follow_up_action": str(triage_item.get("follow_up_action", "")).strip(),
+        }
+
+        forbidden_in_signal = _contains_forbidden_keys(raw_signal, SIGNAL_CANDIDATE_FORBIDDEN_KEYS)
+        forbidden_in_triage = _contains_forbidden_keys(triage_item, SIGNAL_CANDIDATE_FORBIDDEN_KEYS)
+        forbidden_path = forbidden_in_signal or forbidden_in_triage
+
+        parsed_last_seen = _parse_iso8601(signal_evidence["last_seen_at"])
+        age_days = 99999.0
+        if parsed_last_seen is not None:
+            age_days = max(0.0, (now - parsed_last_seen).total_seconds() / 86400.0)
+
+        pass_count = int(signal_evidence["count"]) >= min_count
+        pass_confidence = float(signal_evidence["confidence"]) >= min_confidence
+        pass_recency = age_days <= float(effective_window_days)
+        pass_class = triage_class in SIGNAL_CANDIDATE_ALLOWED_PROMOTION_CLASSES
+
+        status = "hold"
+        reason = "thresholds_not_met"
+        if forbidden_path:
+            status = "reject"
+            reason = f"forbidden_key_detected:{forbidden_path}"
+        elif not effective_collection_enabled:
+            status = "hold"
+            reason = "signals_opt_out_enabled"
+        elif not pass_class:
+            status = "reject"
+            reason = f"triage_class_not_promotable:{triage_class}"
+        elif pass_count and pass_confidence and pass_recency:
+            status = "promote"
+            reason = "thresholds_met"
+        else:
+            hold_reasons: List[str] = []
+            if not pass_count:
+                hold_reasons.append("count")
+            if not pass_confidence:
+                hold_reasons.append("confidence")
+            if not pass_recency:
+                hold_reasons.append("recency")
+            reason = "thresholds_not_met:" + ",".join(hold_reasons)
+
+        score = float(signal_evidence["count"]) * float(signal_evidence["confidence"])
+        score *= 1.0 + float(signal_evidence["triage_confidence"])
+        score = round(score, 4)
+
+        candidate: Dict[str, Any] = {
+            "candidate_id": f"sigcand-{_slug(signal_id)}",
+            "status": status,
+            "reason": reason,
+            "priority_score": score,
+            "signal_evidence": signal_evidence,
+            "promotion_gate": {
+                "min_count": min_count,
+                "min_confidence": min_confidence,
+                "max_age_days": effective_window_days,
+                "observed_age_days": round(age_days, 3),
+                "pass_count": pass_count,
+                "pass_confidence": pass_confidence,
+                "pass_recency": pass_recency,
+                "pass_class": pass_class,
+            },
+            "hypothesis": {},
+        }
+
+        if status == "promote":
+            hypothesis_stub = _signal_hypothesis_stub(
+                base_hypothesis=base_hypothesis,
+                signal_evidence=signal_evidence,
+                triage_class=triage_class,
+            )
+            hypothesis_entry: Dict[str, Any] = {
+                "hypothesis_id": str(hypothesis_stub.get("hypothesis_id", "")).strip(),
+                "title": str(hypothesis_stub.get("title", "")).strip(),
+                "path": "",
+            }
+            if emit_hypotheses_dir is not None:
+                emit_hypotheses_dir.mkdir(parents=True, exist_ok=True)
+                hypothesis_path = emit_hypotheses_dir / f"{hypothesis_entry['hypothesis_id']}.json"
+                _write_json(hypothesis_path, hypothesis_stub)
+                hypothesis_entry["path"] = str(hypothesis_path)
+                promoted_hypotheses.append(str(hypothesis_path))
+            candidate["hypothesis"] = hypothesis_entry
+
+        candidates.append(candidate)
+
+    status_rank = {"promote": 0, "hold": 1, "reject": 2}
+    candidates.sort(
+        key=lambda item: (
+            status_rank.get(str(item.get("status", "")).strip().lower(), 9),
+            -float(item.get("priority_score", 0.0)),
+            str(item.get("candidate_id", "")),
+        )
+    )
+    candidates = candidates[:max_candidates]
+
+    summary = {
+        "signals_total": len([item for item in signals if isinstance(item, dict)]),
+        "triage_items_total": len(triage_index),
+        "candidates_total": len(candidates),
+        "promoted_count": len([item for item in candidates if str(item.get("status", "")) == "promote"]),
+        "held_count": len([item for item in candidates if str(item.get("status", "")) == "hold"]),
+        "rejected_count": len([item for item in candidates if str(item.get("status", "")) == "reject"]),
+        "opt_out_respected": not effective_collection_enabled,
+    }
+
+    output_payload: Dict[str, Any] = {
+        "schema_version": SIGNAL_CANDIDATE_SCHEMA_VERSION,
+        "generated_at": now.isoformat(),
+        "source": {
+            "signals_ledger_path": str(signals_ledger_path),
+            "triage_ledger_path": str(triage_ledger_path),
+            "config_path": str(config_path),
+            "collection_enabled": effective_collection_enabled,
+            "collection_enabled_config": config_enabled,
+            "collection_enabled_ledger": ledger_enabled,
+            "retention_days_ledger": ledger_retention_days,
+            "retention_days_config": config_retention_days,
+            "retention_window_days_effective": effective_window_days,
+        },
+        "thresholds": {
+            "min_count": min_count,
+            "min_confidence": min_confidence,
+            "max_age_days": effective_window_days,
+            "max_candidates": max_candidates,
+        },
+        "summary": summary,
+        "class_summary": triage_payload.get("class_summary", {}),
+        "promoted_hypotheses": promoted_hypotheses,
+        "candidates": candidates,
+    }
+
+    _write_json(output_path, output_payload)
+    return output_payload
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Deterministic hypothesis pipeline v1")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -731,6 +1100,67 @@ def main() -> int:
     package_parser.add_argument("--hypothesis", default=str(DEFAULT_HYPOTHESIS), help="Path to hypothesis JSON")
     package_parser.add_argument("--report", required=True, help="Path to evaluation-report.json")
     package_parser.add_argument("--output", required=True, help="Path for evidence bundle markdown")
+
+    candidates_parser = sub.add_parser(
+        "signals-candidates",
+        help="Generate deterministic hypothesis candidates from derived unmet-intent signal + triage ledgers",
+    )
+    candidates_parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Assistant config path")
+    candidates_parser.add_argument(
+        "--signals-ledger",
+        default=str(DEFAULT_SIGNALS_LEDGER),
+        help="Path to unmet-intent signal ledger JSON",
+    )
+    candidates_parser.add_argument(
+        "--triage-ledger",
+        default=str(DEFAULT_SIGNALS_TRIAGE_LEDGER),
+        help="Path to unmet-intent signal triage ledger JSON",
+    )
+    candidates_parser.add_argument(
+        "--output",
+        default=str(DEFAULT_SIGNAL_CANDIDATE_OUTPUT),
+        help="Path to generated signal-candidate artifact JSON",
+    )
+    candidates_parser.add_argument(
+        "--base-hypothesis",
+        default=str(DEFAULT_HYPOTHESIS),
+        help="Base hypothesis artifact used to materialize promoted candidate stubs",
+    )
+    candidates_parser.add_argument(
+        "--emit-hypotheses-dir",
+        default=None,
+        help="Optional directory where promoted candidate hypothesis stubs are written",
+    )
+    candidates_parser.add_argument(
+        "--min-count",
+        type=int,
+        default=2,
+        help="Minimum signal count required for candidate promotion",
+    )
+    candidates_parser.add_argument(
+        "--min-confidence",
+        type=float,
+        default=0.65,
+        help="Minimum signal confidence required for candidate promotion",
+    )
+    candidates_parser.add_argument(
+        "--max-age-days",
+        type=int,
+        default=90,
+        help="Maximum signal age window (days) before candidate is held",
+    )
+    candidates_parser.add_argument(
+        "--max-candidates",
+        type=int,
+        default=25,
+        help="Maximum number of candidates to return",
+    )
+    candidates_parser.add_argument(
+        "--now",
+        default="",
+        help="Optional ISO timestamp override for deterministic recency checks",
+    )
+    candidates_parser.add_argument("--json", dest="as_json", action="store_true", help="Emit candidate payload JSON")
 
     args = parser.parse_args()
 
@@ -783,6 +1213,45 @@ def main() -> int:
         except Exception as exc:
             print(f"error: unable to package evidence bundle: {exc}")
             return 1
+
+    if args.command == "signals-candidates":
+        min_count = _normalize_int(args.min_count, default=2, minimum=1, maximum=1_000_000)
+        min_confidence = _safe_float(args.min_confidence, default=0.65, minimum=0.0, maximum=1.0)
+        max_age_days = _normalize_int(args.max_age_days, default=90, minimum=1, maximum=365)
+        max_candidates = _normalize_int(args.max_candidates, default=25, minimum=1, maximum=500)
+        emit_hypotheses_dir = (
+            Path(args.emit_hypotheses_dir).expanduser().resolve()
+            if str(args.emit_hypotheses_dir or "").strip()
+            else None
+        )
+        try:
+            payload = _generate_signal_candidates(
+                signals_ledger_path=Path(args.signals_ledger).expanduser().resolve(),
+                triage_ledger_path=Path(args.triage_ledger).expanduser().resolve(),
+                config_path=Path(args.config).expanduser().resolve(),
+                output_path=Path(args.output).expanduser().resolve(),
+                base_hypothesis_path=Path(args.base_hypothesis).expanduser().resolve(),
+                emit_hypotheses_dir=emit_hypotheses_dir,
+                min_count=min_count,
+                min_confidence=min_confidence,
+                max_age_days=max_age_days,
+                max_candidates=max_candidates,
+                now_value=str(args.now or "").strip(),
+            )
+        except Exception as exc:
+            print(f"error: signal candidate generation failed: {exc}")
+            return 1
+
+        if args.as_json:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            summary = payload.get("summary", {})
+            print(f"candidates={summary.get('candidates_total', 0)}")
+            print(f"promoted={summary.get('promoted_count', 0)}")
+            print(f"held={summary.get('held_count', 0)}")
+            print(f"rejected={summary.get('rejected_count', 0)}")
+            print(f"output={Path(args.output).expanduser().resolve()}")
+        return 0
 
     return 1
 

--- a/tools/hypothesis-signal-candidate-check.sh
+++ b/tools/hypothesis-signal-candidate-check.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export ROOT_DIR
+
+tmp_root="$(mktemp -d)"
+export TMP_ROOT="${tmp_root}"
+trap 'rm -rf "${tmp_root}"' EXIT
+
+fixtures_path="${ROOT_DIR}/assistant/hypothesis-signal-candidate-fixtures.json"
+signals_path="${tmp_root}/data/unmet-intent-signals.json"
+triage_path="${tmp_root}/data/unmet-intent-signal-triage.json"
+config_path="${tmp_root}/config.json"
+output_path="${tmp_root}/signal-candidates.json"
+emit_dir="${tmp_root}/generated-hypotheses"
+
+mkdir -p "${tmp_root}/data" "${emit_dir}"
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+root = Path(os.environ["ROOT_DIR"])
+tmp_root = Path(os.environ["TMP_ROOT"])
+fixtures = json.loads((root / "assistant" / "hypothesis-signal-candidate-fixtures.json").read_text(encoding="utf-8"))
+
+signals_payload = fixtures["signals_ledger"]
+triage_payload = fixtures["triage_ledger"]
+
+signals_path = tmp_root / "data" / "unmet-intent-signals.json"
+triage_path = tmp_root / "data" / "unmet-intent-signal-triage.json"
+config_path = tmp_root / "config.json"
+
+signals_path.write_text(json.dumps(signals_payload, indent=2) + "\n", encoding="utf-8")
+triage_path.write_text(json.dumps(triage_payload, indent=2) + "\n", encoding="utf-8")
+config_payload = {
+    "schema_version": 1,
+    "signals": {
+        "enabled": True,
+        "retention_days": int(signals_payload.get("retention_days", 90)),
+        "max_records": int(signals_payload.get("max_records", 300)),
+    },
+}
+config_path.write_text(json.dumps(config_payload, indent=2) + "\n", encoding="utf-8")
+PY
+
+export CONFIG_PATH="${config_path}"
+threshold_args=()
+while IFS= read -r line; do
+  threshold_args+=("${line}")
+done < <(python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+root = Path(os.environ["ROOT_DIR"])
+fixtures = json.loads((root / "assistant" / "hypothesis-signal-candidate-fixtures.json").read_text(encoding="utf-8"))
+thresholds = fixtures.get("thresholds", {})
+print("--min-count")
+print(str(int(thresholds.get("min_count", 2))))
+print("--min-confidence")
+print(str(float(thresholds.get("min_confidence", 0.65))))
+print("--max-age-days")
+print(str(int(thresholds.get("max_age_days", 90))))
+print("--max-candidates")
+print(str(int(thresholds.get("max_candidates", 10))))
+print("--now")
+print(str(fixtures.get("now", "")))
+PY
+)
+
+candidate_json="$(python3 "${ROOT_DIR}/tools/hypothesis-pipeline.py" signals-candidates \
+  --config "${config_path}" \
+  --signals-ledger "${signals_path}" \
+  --triage-ledger "${triage_path}" \
+  --output "${output_path}" \
+  --base-hypothesis "${ROOT_DIR}/assistant/hypotheses/phase3-hypothesis-pipeline-v1.json" \
+  --emit-hypotheses-dir "${emit_dir}" \
+  "${threshold_args[@]}" \
+  --json)"
+export CANDIDATE_JSON="${candidate_json}"
+
+python3 - <<'PY'
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+root = Path(os.environ["ROOT_DIR"])
+fixtures = json.loads((root / "assistant" / "hypothesis-signal-candidate-fixtures.json").read_text(encoding="utf-8"))
+expectations = fixtures["expectations"]
+payload = json.loads(os.environ["CANDIDATE_JSON"])
+
+summary = payload.get("summary", {})
+if int(summary.get("promoted_count", -1)) != int(expectations["promoted_count"]):
+    raise SystemExit("promoted_count mismatch")
+if int(summary.get("held_count", -1)) != int(expectations["held_count"]):
+    raise SystemExit("held_count mismatch")
+if int(summary.get("rejected_count", -1)) != int(expectations["rejected_count"]):
+    raise SystemExit("rejected_count mismatch")
+
+status_by_signal = expectations["status_by_signal"]
+by_signal = {}
+for item in payload.get("candidates", []):
+    if not isinstance(item, dict):
+        continue
+    signal = item.get("signal_evidence", {})
+    if not isinstance(signal, dict):
+        continue
+    signal_id = str(signal.get("signal_id", ""))
+    if signal_id:
+        by_signal[signal_id] = item
+
+for signal_id, expected_status in status_by_signal.items():
+    actual = str(by_signal.get(signal_id, {}).get("status", ""))
+    if actual != expected_status:
+        raise SystemExit(f"status mismatch for {signal_id}: expected {expected_status}, got {actual}")
+
+promoted_expected = set(expectations["promoted_signal_ids"])
+promoted_actual = {
+    str(item.get("signal_evidence", {}).get("signal_id", ""))
+    for item in payload.get("candidates", [])
+    if isinstance(item, dict) and str(item.get("status", "")) == "promote"
+}
+if promoted_actual != promoted_expected:
+    raise SystemExit(f"promoted signal ids mismatch: expected {sorted(promoted_expected)}, got {sorted(promoted_actual)}")
+
+for item in payload.get("candidates", []):
+    if not isinstance(item, dict):
+        continue
+    if str(item.get("status", "")) != "promote":
+        continue
+    hypothesis = item.get("hypothesis", {})
+    if not isinstance(hypothesis, dict):
+        raise SystemExit("promoted candidate missing hypothesis block")
+    hypothesis_path = Path(str(hypothesis.get("path", "")).strip())
+    if not hypothesis_path.exists():
+        raise SystemExit(f"promoted hypothesis file missing: {hypothesis_path}")
+    proc = subprocess.run(
+        [
+            "python3",
+            str(root / "tools" / "hypothesis-pipeline.py"),
+            "validate",
+            "--hypothesis",
+            str(hypothesis_path),
+        ],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise SystemExit(f"generated hypothesis contract invalid: {hypothesis_path}\n{proc.stdout}\n{proc.stderr}")
+
+forbidden = {"raw_text", "transcript", "conversation", "messages", "content"}
+
+def walk(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if str(key).strip().lower() in forbidden:
+                return str(key)
+            found = walk(nested)
+            if found:
+                return found
+    elif isinstance(value, list):
+        for nested in value:
+            found = walk(nested)
+            if found:
+                return found
+    return ""
+
+found = walk(payload)
+if found:
+    raise SystemExit(f"forbidden key leaked into candidate payload: {found}")
+PY
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+config_path = Path(os.environ["CONFIG_PATH"])
+cfg = json.loads(config_path.read_text(encoding="utf-8"))
+signals = cfg.get("signals", {})
+if not isinstance(signals, dict):
+    signals = {}
+signals["enabled"] = False
+cfg["signals"] = signals
+config_path.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+PY
+
+opt_out_json="$(python3 "${ROOT_DIR}/tools/hypothesis-pipeline.py" signals-candidates \
+  --config "${config_path}" \
+  --signals-ledger "${signals_path}" \
+  --triage-ledger "${triage_path}" \
+  --output "${tmp_root}/signal-candidates-opt-out.json" \
+  --base-hypothesis "${ROOT_DIR}/assistant/hypotheses/phase3-hypothesis-pipeline-v1.json" \
+  "${threshold_args[@]}" \
+  --json)"
+export OPT_OUT_JSON="${opt_out_json}"
+
+python3 - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["OPT_OUT_JSON"])
+summary = payload.get("summary", {})
+fixtures = json.loads(
+    open(os.environ["ROOT_DIR"] + "/assistant/hypothesis-signal-candidate-fixtures.json", encoding="utf-8").read()
+)
+if int(summary.get("promoted_count", -1)) != int(fixtures["expectations"]["opt_out_promoted_count"]):
+    raise SystemExit("opt-out promoted_count mismatch")
+if not bool(summary.get("opt_out_respected", False)):
+    raise SystemExit("opt-out signal was not respected")
+PY


### PR DESCRIPTION
## Summary
- extend `tools/hypothesis-pipeline.py` with `signals-candidates` to convert derived unmet-intent signal + triage ledgers into deterministic hypothesis candidate artifacts
- enforce deterministic promotion thresholds (count/confidence/recency), opt-out-aware behavior, and derived-signal-only redaction guards for candidate generation
- add optional promoted hypothesis stub emission for downstream canary-gated hypothesis pipeline evaluation
- add deterministic fixture coverage + reusable check harness + hypothesis CI workflow step for signal-derived candidate generation
- sync architecture/contract/docs/state and include mandatory privacy + QA gate artifacts for lane `#113`

Closes #113

## Track Declaration
- [ ] `assistant-track`
- [x] `framework-track`
- [ ] Cross-track (`assistant-track` + `framework-track`)

## Risk Level
- [ ] Low
- [x] Medium
- [ ] High (requires explicit maintainer review before merge)

## Self-Evolution Applicability
- [x] Applies: this PR changes self-evolution behavior/governance.
- [ ] Not applicable: no self-evolution behavior/governance changes.

## Self-Evolution Evidence (required when applicability is "Applies")
- Baseline evidence: `#111` + `#112` provide derived signal extraction and deterministic triage, but no thresholded hypothesis-candidate integration path.
- Delta observed: `hypothesis-pipeline.py signals-candidates` now emits deterministic `promote|hold|reject` candidate artifacts with triage-linked signal evidence and optional promoted hypothesis stubs.
- Thresholds and guardrails: candidate promotion requires count/confidence/recency thresholds, promotable triage classes only, opt-out enforcement, and derived-signal-only forbidden-key rejection.
- Rollback/fallback: revert this lane to return to pre-existing manual hypothesis proposal flow; fallback remains hold/manual review with no automated candidate promotion.
- Risk notes: heuristic thresholding may under/over-suggest candidates; mitigated by suggestion-mode outputs, explicit reasons, privacy guards, and unchanged canary/rollback gating in evaluation pipeline.

## Validation
- [x] `make check-all`
- [ ] `make test-smoke` (if assistant/runtime behavior changed)
- [ ] `make test-uat` (required for assistant feature changes)
- [x] Additional targeted checks documented below

Additional targeted checks:
- `python3 -m py_compile tools/hypothesis-pipeline.py`
- `make hypothesis-dry-run`
- `make hypothesis-hold-fixture`
- `make hypothesis-failure-fixture` (expected non-zero)
- `make hypothesis-signals-candidate-fixture`
- `make uat-policy`
- `make quality-matrix`
- `make generate-indexes`

## Checklist
- [x] Changes are small, safe, and incremental
- [x] No breaking changes to structure or website
- [x] Docs follow repo markdown standards
- [x] Links added/updated were verified
- [x] Track and risk are declared
- [x] Self-evolution applicability declared and rubric completed when required
- [x] Handoff notes included (files changed, validations, follow-ups)
- [x] New feature surfaces include UAT updates in this PR

## UAT Change Justification
No UAT governance file changes in this lane (`assistant/feature-catalog.json`, `assistant/uat-scenarios.json`, `tools/uat-runner.py`, `tools/check-uat-policy.py` unchanged). Candidate integration is validated via deterministic hypothesis-pipeline fixture coverage and CI workflow updates.

## Notes
- Mandatory memory/privacy + QA gate artifacts included:
  - `infrastructure/privacy-memory-review-2026-02-14-signal-hypothesis-candidates.md`
  - `infrastructure/qa-evaluation-2026-02-14-signal-hypothesis-candidates.md`
