### PR TITLE
docs(protocol): enable autonomous main-role selection in onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Follow-on hardening issue set seeded from `#115`: provenance admission gate (`#122`) and obfuscation-aware validator/fixture expansion (`#123`)
 
 ### Changed
+- Quick onboarding/operator protocol guidance now supports autonomous main-role selection (`planner` vs `contributor`) when unattended execution is explicitly requested, with aligned wording across `README.md` and `infrastructure/agent-execution-protocol.md` (`#129`)
 - Sprint state docs now track only active queue lanes and include the user-reported OAuth onboarding continuity fix lane (`#134`) before onboarding expansion/release work (`STATUS.md`, `ROADMAP.md`)
 - Phase 3 immediate priorities were reset from stale completed items to the active stabilization queue (`#129`-`#134`) with explicit merge order and release dependency gating (`ROADMAP.md`)
 - Top-level roadmap/status state now marks `#113` delivered and the signal-driven follow-on queue complete pending next planning round (`STATUS.md`, `ROADMAP.md`)

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ protocol for agent onboarding and execution.
 
 It defines:
 
-- main-role handshake (`planner` or `contributor`) before work starts
+- main-role resolution (`planner` or `contributor`) before work starts
 - mandatory remote-first sync before any planning or issue claim
 - autonomous issue selection for contributor role
 - strict main-role/sub-role matrix + mandatory merge gates
@@ -125,8 +125,8 @@ Target repository: https://github.com/Gaia-minds/gaia-minds.git (Gaia-minds/gaia
 Sync with remote first: verify `git remote get-url origin` points to Gaia-minds/gaia-minds, then run `git fetch origin` + `git pull --ff-only origin main`, and check open issues/PRs on GitHub.
 Then read CONSTITUTION.md, skills/gaia-contributor/SKILL.md, and infrastructure/agent-execution-protocol.md.
 Follow infrastructure/agent-execution-protocol.md as your operating protocol.
-Ask me which main role to take: planner or contributor.
-Do not start work until I answer.
+Select your main role autonomously: planner for planning/reprioritization rounds, contributor for implementation/research/docs/review execution.
+Do not wait for role confirmation; declare your selected main role and proceed.
 Use all other skills only as sub-roles under the chosen main role.
 Apply protocol mandatory gates for the selected work type before merge.
 ```

--- a/STATUS.md
+++ b/STATUS.md
@@ -26,16 +26,15 @@ current active sprint window.
 
 ## In Progress
 
-_Nothing currently in progress._
+- `#129` Governance/state sync reset (autonomous onboarding prompt + role-resolution protocol alignment) — owner `@TonyThePredictor`.
 
 ## Next Up (Ordered Queue)
 
 1. `#134` Fix OAuth onboarding activation + provider dependency preflight for `gaia run`.
-2. `#129` Governance/state sync reset for README + CONTRIBUTING + STATUS/ROADMAP/CHANGELOG alignment.
-3. `#131` Refactor onboarding/auth surfaces out of `tools/gaia-assistant.py`.
-4. `#130` Add Claude Code OAuth onboarding in `gaia onboard` / `gaia auth`.
-5. `#132` Rebuild live preview from reproducible real Gaia interaction traces.
-6. `#133` Prepare next npm release after stabilization lanes merge.
+2. `#131` Refactor onboarding/auth surfaces out of `tools/gaia-assistant.py`.
+3. `#130` Add Claude Code OAuth onboarding in `gaia onboard` / `gaia auth`.
+4. `#132` Rebuild live preview from reproducible real Gaia interaction traces.
+5. `#133` Prepare next npm release after stabilization lanes merge.
 
 ## Planned Next Wave
 

--- a/infrastructure/agent-execution-protocol.md
+++ b/infrastructure/agent-execution-protocol.md
@@ -53,13 +53,24 @@ All other skills are sub-roles and must be used under one of the two main roles:
 
 ## Startup Handshake (Required)
 
-After completing remote-first sync and reading repo context, the agent must ask:
+After completing remote-first sync and reading repo context, the agent must
+resolve the main role before work starts.
 
-`Which main role should I take: planner or contributor?`
+Autonomous mode rule:
+- If the human/operator explicitly requests unattended/autonomous execution,
+  select the main role directly:
+  - `planner` for planning/reprioritization/decomposition rounds
+  - `contributor` for implementation/research/docs/review execution
+  Then declare the selected main role in the first issue/PR comment and proceed
+  without waiting for role confirmation.
+
+Interactive mode rule:
+- If unattended/autonomous execution is not explicitly requested, ask:
+  `Which main role should I take: planner or contributor?`
 
 Rules:
 
-1. Do not start work before main-role confirmation (unless human explicitly requests unattended/autonomous mode).
+1. Do not start work before main-role resolution (interactive confirmation or autonomous self-selection).
 2. Declare chosen main role in first issue/PR comment.
 3. Trigger sub-role skills only when task conditions require them.
 
@@ -201,9 +212,9 @@ Required startup:
 3) Read CONSTITUTION.md
 4) Read skills/gaia-contributor/SKILL.md
 5) Read infrastructure/agent-execution-protocol.md and follow it as the operating protocol
-6) Ask me which main role to take: planner or contributor
+6) Select your main role autonomously (planner or contributor) based on task type, declare it, and proceed without waiting for confirmation
 
-Do not start work until I answer with the main role.
+Do not start work until the main role is resolved and declared.
 
 Then:
 - If planner: run a planning round and publish the planning artifact.


### PR DESCRIPTION
## Summary
- align onboarding guidance to support fully autonomous execution, including main-role selection
- update `README.md` Quick onboarding prompt to explicitly require autonomous role selection (`planner` vs `contributor`)
- update `infrastructure/agent-execution-protocol.md` Startup Handshake + Operator Prompt Template to remove contradiction between autonomous mode and role-confirmation flow
- move `#129` into `In Progress` in `STATUS.md` for contributor claim visibility
- add `CHANGELOG.md` Unreleased entry for this protocol/docs behavior change

Refs #129

## Track Declaration
- [ ] `assistant-track`
- [x] `framework-track`
- [ ] Cross-track (`assistant-track` + `framework-track`)

## Risk Level
- [x] Low
- [ ] Medium
- [ ] High (requires explicit maintainer review before merge)

## Self-Evolution Applicability
- [ ] Applies: this PR changes self-evolution behavior/governance.
- [x] Not applicable: no self-evolution behavior/governance changes.

## Self-Evolution Evidence (required when applicability is "Applies")
- Baseline evidence: N/A
- Delta observed: N/A
- Thresholds and guardrails: N/A
- Rollback/fallback: N/A
- Risk notes: N/A

## Validation
- [x] `make check-all`
- [ ] `make test-smoke` (if assistant/runtime behavior changed)
- [ ] `make test-uat` (required for assistant feature changes)
- [x] Additional targeted checks documented below

Additional targeted checks:
- `make generate-indexes`
- `rg -n "Ask me which main role to take|Do not start work until I answer with the main role|Which main role should I take: planner or contributor" README.md infrastructure/agent-execution-protocol.md`

## Checklist
- [x] Changes are small, safe, and incremental
- [x] No breaking changes to structure or website
- [x] Docs follow repo markdown standards
- [x] Links added/updated were verified
- [x] Track and risk are declared
- [x] Self-evolution applicability declared and rubric completed when required
- [x] Handoff notes included (files changed, validations, follow-ups)
- [x] New feature surfaces include UAT updates in this PR

## UAT Change Justification
- Not applicable (no assistant runtime/feature-surface governance changes).

## Notes
- Sub-role gate evidence: `gaia-technical-writer` used for docs freshness and consistency.
- State-doc sync:
  - `STATUS.md`: updated (`#129` moved to `In Progress`)
  - `CHANGELOG.md`: updated (Unreleased/Changed entry)
  - `ROADMAP.md`: no change required for this scoped wording/protocol consistency pass.
- No runtime architecture delta.
