### PR TITLE
refactor: extract onboarding/auth helpers from gaia-assistant

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -23,18 +23,18 @@ current active sprint window.
 - `Phase 3 Obfuscation-Aware Skill Validation Hardening` (`#123`, PR #126)
 - `Phase 3 Skill-First Unmet-Intent Triage` (`#112`, PR #127)
 - `Phase 3 Signal-Derived Hypothesis Candidate Integration` (`#113`, PR #128)
+- `Sprint OAuth onboarding activation + provider preflight fix` (`#134`, PR #136)
 
 ## In Progress
 
 - `#129` Governance/state sync reset (autonomous onboarding prompt + role-resolution protocol alignment) — owner `@TonyThePredictor`.
-- `#134` Fix OAuth onboarding activation + provider dependency preflight for `gaia run` — owner `@TonyThePredictor`.
+- `#131` Refactor onboarding/auth surfaces out of `tools/gaia-assistant.py` — owner `@TonyThePredictor`.
 
 ## Next Up (Ordered Queue)
 
-1. `#131` Refactor onboarding/auth surfaces out of `tools/gaia-assistant.py`.
-2. `#130` Add Claude Code OAuth onboarding in `gaia onboard` / `gaia auth`.
-3. `#132` Rebuild live preview from reproducible real Gaia interaction traces.
-4. `#133` Prepare next npm release after stabilization lanes merge.
+1. `#130` Add Claude Code OAuth onboarding in `gaia onboard` / `gaia auth`.
+2. `#132` Rebuild live preview from reproducible real Gaia interaction traces.
+3. `#133` Prepare next npm release after stabilization lanes merge.
 
 ## Planned Next Wave
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -821,6 +821,8 @@ Runtime module layout note:
 
 - CLI entrypoint remains `tools/gaia-assistant.py`
 - parser/command registration is extracted to `tools/gaia_assistant_parser.py`
+- onboarding/auth provider registry + profile-link helpers are extracted to
+  `tools/gaia_assistant_onboarding.py`
 
 The self-evolution loop planner supports Anthropic, OpenAI, and OpenRouter in
 non-dry runs. Tier-2 LLM alignment checks currently run only with Anthropic;

--- a/infrastructure/architecture.md
+++ b/infrastructure/architecture.md
@@ -1133,6 +1133,35 @@ Lane: `Refactor tools/gaia-assistant.py into modular command packages` (`#106`)
 - No policy or capability model changes were introduced in this lane.
 - Parser behavior parity is validated through smoke/UAT/check gates before merge.
 
+## Phase 3 Delta: Onboarding/Auth Surface Extraction (2026-02-15)
+
+Lane: `Refactor onboarding/auth surfaces out of tools/gaia-assistant.py` (`#131`)
+
+### Runtime/module boundary changes
+
+- Added dedicated onboarding/auth helper module:
+  - `tools/gaia_assistant_onboarding.py`
+- Extracted provider registry defaults and OAuth profile-link helper flows into
+  the new module, including:
+  - provider metadata defaults
+  - Codex OAuth credential parsing/profile-id derivation
+  - linked profile lookup and runtime token availability checks
+  - runtime dependency preflight helper logic used by `gaia run`
+- `tools/gaia-assistant.py` remains the command entrypoint and delegates these
+  helper paths through wrapper functions.
+
+### Packaging and entrypoint compatibility
+
+- Existing launcher path remains unchanged:
+  - `bin/gaia.js` still executes `tools/gaia-assistant.py`
+- npm package payload includes extracted onboarding module:
+  - `package.json` -> `files[]` includes `tools/gaia_assistant_onboarding.py`
+
+### Safety/quality notes
+
+- CLI command names and parser surfaces are unchanged.
+- Behavior parity is enforced through smoke/UAT/check gates.
+
 ---
 
 ## Open Technical Questions

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bin/gaia.js",
     "tools/gaia-assistant.py",
     "tools/gaia_assistant_parser.py",
+    "tools/gaia_assistant_onboarding.py",
     "tools/agent-actions.py",
     "tools/agent-alignment.py",
     "tools/agent_actions.py",

--- a/tools/gaia-assistant.py
+++ b/tools/gaia-assistant.py
@@ -12,7 +12,6 @@ import base64
 import getpass
 import hashlib
 import html
-import importlib.util
 import json
 import os
 import re
@@ -29,6 +28,7 @@ import urllib.request
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+import gaia_assistant_onboarding as onboarding
 from gaia_assistant_parser import build_parser as build_modular_parser
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -50,9 +50,9 @@ DEFAULT_CODEX_AUTH_PATH = Path(
 DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-5-20250929"
 DEFAULT_OPENAI_MODEL = "gpt-4.1-mini"
 DEFAULT_OPENROUTER_MODEL = "openrouter/auto"
-ONBOARD_PROVIDER_CHOICES = ("openrouter", "openai", "anthropic", "openai-codex")
+ONBOARD_PROVIDER_CHOICES = onboarding.ONBOARD_PROVIDER_CHOICES
 PROFILE_VERBOSITY_CHOICES = ("concise", "balanced", "detailed")
-PROFILE_PROVIDER_CHOICES = ("openrouter", "openai", "anthropic", "openai-codex")
+PROFILE_PROVIDER_CHOICES = onboarding.PROFILE_PROVIDER_CHOICES
 RUNTIME_REASONING_PROVIDER_CHOICES = ("anthropic", "openai", "openrouter")
 RESPONSE_PROFILE_CHOICES = ("auto", "concise", "balanced", "detailed")
 RESPONSE_PROFILE_DEFAULT = "balanced"
@@ -286,22 +286,8 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     },
     "auth": {
         "providers": {
-            "anthropic": {
-                "subscription_oauth_supported": False,
-                "api_key_env": "ANTHROPIC_API_KEY",
-            },
-            "openai": {
-                "subscription_oauth_supported": True,
-                "api_key_env": "OPENAI_API_KEY",
-            },
-            "openai-codex": {
-                "subscription_oauth_supported": True,
-                "api_key_env": "",
-            },
-            "openrouter": {
-                "subscription_oauth_supported": False,
-                "api_key_env": "OPENROUTER_API_KEY",
-            },
+            name: dict(provider_cfg)
+            for name, provider_cfg in onboarding.AUTH_PROVIDER_DEFAULTS.items()
         }
     },
     "tracks": {
@@ -4545,128 +4531,36 @@ def _configure_api_key_provider(
 
 
 def _resolve_codex_auth_path(override_path: Optional[str]) -> Path:
-    if override_path:
-        return Path(override_path).expanduser()
-    return DEFAULT_CODEX_AUTH_PATH
+    return onboarding.resolve_codex_auth_path(override_path, DEFAULT_CODEX_AUTH_PATH)
 
 
 def _resolve_gaia_auth_store(cfg_path: Path, override_path: Optional[str]) -> Path:
-    if override_path:
-        return Path(override_path).expanduser()
-    cfg = _load_json(cfg_path)
-    if cfg:
-        store = cfg.get("auth", {}).get("store_path")
-        if isinstance(store, str) and store.strip():
-            return Path(store).expanduser()
-    return cfg_path.parent / "auth-profiles.json"
+    return onboarding.resolve_gaia_auth_store(
+        cfg_path,
+        override_path,
+        cfg_path.parent / "auth-profiles.json",
+        _load_json,
+    )
 
 
 def _load_gaia_auth_store(path: Path) -> Dict[str, Any]:
-    payload = _load_json(path)
-    if not payload:
-        return {"version": 1, "profiles": {}}
-    if not isinstance(payload.get("profiles"), dict):
-        payload["profiles"] = {}
-    if "version" not in payload:
-        payload["version"] = 1
-    return payload
+    return onboarding.load_gaia_auth_store(path, _load_json)
 
 
 def _save_gaia_auth_store(path: Path, payload: Dict[str, Any]) -> None:
-    _write_secret_json(path, payload)
-
-
-def _decode_jwt_payload(token: str) -> Dict[str, Any]:
-    parts = token.split(".")
-    if len(parts) < 2:
-        return {}
-    payload = parts[1]
-    payload += "=" * (-len(payload) % 4)
-    try:
-        raw = base64.urlsafe_b64decode(payload.encode("ascii")).decode("utf-8")
-        claims = json.loads(raw)
-        return claims if isinstance(claims, dict) else {}
-    except (ValueError, UnicodeDecodeError, json.JSONDecodeError):
-        return {}
+    onboarding.save_gaia_auth_store(path, payload, _write_secret_json)
 
 
 def _read_codex_cli_credentials(codex_auth_path: Path) -> Optional[Dict[str, Any]]:
-    payload = _load_json(codex_auth_path)
-    if not payload:
-        return None
-    tokens = payload.get("tokens")
-    if not isinstance(tokens, dict):
-        return None
-
-    access = tokens.get("access_token")
-    refresh = tokens.get("refresh_token")
-    account_id = tokens.get("account_id")
-    if not isinstance(access, str) or not access.strip():
-        return None
-    if not isinstance(refresh, str) or not refresh.strip():
-        return None
-
-    claims = _decode_jwt_payload(access)
-    exp_s = claims.get("exp")
-    expires_ms: int
-    if isinstance(exp_s, (int, float)):
-        expires_ms = int(exp_s * 1000)
-    else:
-        # Conservative fallback if JWT claims aren't available.
-        expires_ms = int(datetime.now(timezone.utc).timestamp() * 1000) + 3600 * 1000
-
-    profile_claims = claims.get("https://api.openai.com/profile")
-    email = ""
-    if isinstance(profile_claims, dict):
-        raw_email = profile_claims.get("email")
-        if isinstance(raw_email, str):
-            email = raw_email.strip()
-
-    auth_claims = claims.get("https://api.openai.com/auth")
-    if not account_id and isinstance(auth_claims, dict):
-        auth_account_id = auth_claims.get("chatgpt_account_id")
-        if isinstance(auth_account_id, str) and auth_account_id.strip():
-            account_id = auth_account_id.strip()
-
-    return {
-        "type": "oauth",
-        "provider": "openai-codex",
-        "access": access,
-        "refresh": refresh,
-        "expires": expires_ms,
-        "account_id": str(account_id).strip() if isinstance(account_id, str) else "",
-        "email": email,
-        "source": "codex-cli",
-        "updated_at": datetime.now(timezone.utc).isoformat(),
-    }
+    return onboarding.read_codex_cli_credentials(codex_auth_path, _load_json)
 
 
 def _is_expired(credential: Dict[str, Any]) -> bool:
-    expires = credential.get("expires")
-    if not isinstance(expires, (int, float)):
-        return False
-    return int(expires) <= int(datetime.now(timezone.utc).timestamp() * 1000)
+    return onboarding.is_expired(credential)
 
 
 def _format_expiry(credential: Dict[str, Any]) -> str:
-    expires = credential.get("expires")
-    if not isinstance(expires, (int, float)):
-        return "unknown"
-    try:
-        dt = datetime.fromtimestamp(int(expires) / 1000, tz=timezone.utc)
-        return dt.isoformat()
-    except (OSError, ValueError):
-        return "unknown"
-
-
-def _profile_id_for_credential(provider: str, credential: Dict[str, Any]) -> str:
-    email = credential.get("email")
-    if isinstance(email, str) and email.strip():
-        return f"{provider}:{email.strip().lower()}"
-    account_id = credential.get("account_id")
-    if isinstance(account_id, str) and account_id.strip():
-        return f"{provider}:{account_id.strip()}"
-    return f"{provider}:default"
+    return onboarding.format_expiry(credential)
 
 
 def _link_profile(
@@ -4702,63 +4596,17 @@ def _codex_login() -> int:
     return subprocess.run(cmd).returncode
 
 
-def _can_auto_align_codex_runtime_defaults(cfg: Dict[str, Any]) -> bool:
-    reasoning = cfg.get("reasoning", {})
-    reasoning = reasoning if isinstance(reasoning, dict) else {}
-    profile = cfg.get("profile", {})
-    profile = profile if isinstance(profile, dict) else {}
-
-    if _normalize_bool_default(reasoning.get("explicit_provider_override", False), False):
-        return False
-
-    current_provider = str(reasoning.get("provider", "")).strip().lower()
-    current_model = str(reasoning.get("model", "")).strip()
-    current_profile_provider = str(profile.get("default_provider", "")).strip().lower()
-
-    # Respect user-selected runtime choices; only auto-align untouched defaults.
-    has_provider_override = current_provider not in ("", "anthropic")
-    has_model_override = bool(current_model and current_model != DEFAULT_ANTHROPIC_MODEL)
-    has_profile_provider_override = current_profile_provider not in ("", "anthropic", "openai-codex")
-    return not (has_provider_override or has_model_override or has_profile_provider_override)
-
-
 def _apply_oauth_runtime_defaults(cfg_path: Path, oauth_provider: str) -> bool:
-    if oauth_provider != "openai-codex":
-        return False
-
-    cfg = _ensure_config_exists(cfg_path)
-    if not _can_auto_align_codex_runtime_defaults(cfg):
-        return False
-
-    reasoning = cfg.setdefault("reasoning", {})
-    if not isinstance(reasoning, dict):
-        reasoning = {}
-        cfg["reasoning"] = reasoning
-    profile = cfg.setdefault("profile", {})
-    if not isinstance(profile, dict):
-        profile = {}
-        cfg["profile"] = profile
-
-    changed = False
-    if str(reasoning.get("provider", "")).strip().lower() != "openai":
-        reasoning["provider"] = "openai"
-        changed = True
-
-    existing_model = str(reasoning.get("model", "")).strip()
-    if not existing_model or existing_model == DEFAULT_ANTHROPIC_MODEL:
-        if existing_model != DEFAULT_OPENAI_MODEL:
-            reasoning["model"] = DEFAULT_OPENAI_MODEL
-            changed = True
-
-    profile_provider = str(profile.get("default_provider", "")).strip().lower()
-    if profile_provider in ("", "anthropic", "openai-codex") and profile_provider != "openai":
-        profile["default_provider"] = "openai"
-        changed = True
-
-    if changed:
-        reasoning["explicit_provider_override"] = False
-        _write_json(cfg_path, _normalize_config(cfg))
-    return changed
+    return onboarding.apply_oauth_runtime_defaults(
+        cfg_path,
+        oauth_provider,
+        ensure_config_exists=_ensure_config_exists,
+        normalize_config=_normalize_config,
+        write_json=_write_json,
+        default_anthropic_model=DEFAULT_ANTHROPIC_MODEL,
+        default_openai_model=DEFAULT_OPENAI_MODEL,
+        normalize_bool_default=_normalize_bool_default,
+    )
 
 
 def _import_codex_profile_to_gaia(
@@ -4767,104 +4615,40 @@ def _import_codex_profile_to_gaia(
     codex_auth_path: Path,
     gaia_auth_store: Path,
 ) -> Tuple[int, str, bool]:
-    if provider != "openai-codex":
-        return 1, "", False
-    credential = _read_codex_cli_credentials(codex_auth_path)
-    if credential is None:
+    rc, profile_id, runtime_aligned = onboarding.import_codex_profile_to_gaia(
+        cfg_path,
+        provider,
+        codex_auth_path,
+        gaia_auth_store,
+        read_codex_cli_credentials_fn=_read_codex_cli_credentials,
+        load_gaia_auth_store_fn=_load_gaia_auth_store,
+        save_gaia_auth_store_fn=_save_gaia_auth_store,
+        link_profile_fn=_link_profile,
+        apply_oauth_runtime_defaults_fn=_apply_oauth_runtime_defaults,
+    )
+    if rc != 0 and provider == "openai-codex":
         print(
             "Codex credentials not found after login.\n"
             f"Expected auth file: {codex_auth_path}",
             file=sys.stderr,
         )
-        return 1, "", False
-
-    store = _load_gaia_auth_store(gaia_auth_store)
-    profiles = store.setdefault("profiles", {})
-    if not isinstance(profiles, dict):
-        profiles = {}
-        store["profiles"] = profiles
-
-    profile_id = _profile_id_for_credential(provider, credential)
-    profiles[profile_id] = credential
-    _save_gaia_auth_store(gaia_auth_store, store)
-    _link_profile(cfg_path, provider, profile_id, "gaia-local", gaia_auth_store)
-    runtime_aligned = _apply_oauth_runtime_defaults(cfg_path, provider)
-    return 0, profile_id, runtime_aligned
+    return rc, profile_id, runtime_aligned
 
 
 def _read_linked_credential(active_profile: Dict[str, Any]) -> Tuple[Optional[Dict[str, Any]], str]:
-    source = str(active_profile.get("source", "")).strip()
-    provider = str(active_profile.get("provider", "")).strip()
-    profile_id = str(active_profile.get("profile_id", "")).strip()
-    store_raw = str(active_profile.get("store_path", "")).strip()
-    if not store_raw:
-        return None, "linked profile store_path is empty"
-
-    store_path = Path(store_raw).expanduser()
-    if not store_path.exists():
-        return None, f"linked profile store not found: {store_path}"
-
-    if source == "gaia-local":
-        profiles = _load_gaia_auth_store(store_path).get("profiles", {})
-    else:
-        return None, f"unknown auth source: {source}"
-
-    if not isinstance(profiles, dict):
-        return None, f"profile store is invalid: {store_path}"
-
-    credential = profiles.get(profile_id)
-    if not isinstance(credential, dict):
-        return None, f"linked profile missing in store: {profile_id} ({store_path})"
-
-    if provider and credential.get("provider") != provider:
-        return None, (
-            f"linked profile provider mismatch for {profile_id}: "
-            f"expected {provider}, got {credential.get('provider')}"
-        )
-
-    return credential, ""
+    return onboarding.read_linked_credential(active_profile, _load_gaia_auth_store)
 
 
 def _linked_openai_oauth_access_token(cfg: Dict[str, Any]) -> Tuple[str, str]:
-    auth_cfg = cfg.get("auth", {})
-    auth_cfg = auth_cfg if isinstance(auth_cfg, dict) else {}
-    active_profile = auth_cfg.get("active_profile")
-    if not isinstance(active_profile, dict):
-        return "", "no linked OAuth profile in launcher config"
-
-    provider = str(active_profile.get("provider", "")).strip().lower()
-    if provider != "openai-codex":
-        return "", "linked profile is not openai-codex"
-
-    credential, error = _read_linked_credential(active_profile)
-    if credential is None:
-        return "", error
-    if _is_expired(credential):
-        return "", "linked OAuth profile is expired"
-
-    access_token = str(credential.get("access", "")).strip()
-    if not access_token:
-        return "", "linked OAuth profile access token is missing"
-    return access_token, ""
+    return onboarding.linked_openai_oauth_access_token(
+        cfg,
+        read_linked_credential_fn=_read_linked_credential,
+        is_expired_fn=_is_expired,
+    )
 
 
 def _provider_runtime_dependency_issue(provider: str, env: Dict[str, str]) -> Optional[str]:
-    normalized = str(provider).strip().lower()
-    if normalized == "anthropic":
-        if importlib.util.find_spec("anthropic") is None:
-            return "anthropic-package"
-        if not env.get("ANTHROPIC_API_KEY", "").strip():
-            return "anthropic-key"
-        return None
-    if normalized == "openai":
-        if not env.get("OPENAI_API_KEY", "").strip():
-            return "openai-key"
-        return None
-    if normalized == "openrouter":
-        if not env.get("OPENROUTER_API_KEY", "").strip():
-            return "openrouter-key"
-        return None
-    return "unsupported-provider"
+    return onboarding.provider_runtime_dependency_issue(provider, env)
 
 
 def cmd_init(args: argparse.Namespace) -> int:

--- a/tools/gaia_assistant_onboarding.py
+++ b/tools/gaia_assistant_onboarding.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Onboarding/auth provider registry and profile-link helpers for Gaia assistant."""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Tuple
+
+
+ONBOARD_PROVIDER_CHOICES = ("openrouter", "openai", "anthropic", "openai-codex")
+PROFILE_PROVIDER_CHOICES = ("openrouter", "openai", "anthropic", "openai-codex")
+AUTH_PROVIDER_DEFAULTS: Dict[str, Dict[str, Any]] = {
+    "anthropic": {
+        "subscription_oauth_supported": False,
+        "api_key_env": "ANTHROPIC_API_KEY",
+    },
+    "openai": {
+        "subscription_oauth_supported": True,
+        "api_key_env": "OPENAI_API_KEY",
+    },
+    "openai-codex": {
+        "subscription_oauth_supported": True,
+        "api_key_env": "",
+    },
+    "openrouter": {
+        "subscription_oauth_supported": False,
+        "api_key_env": "OPENROUTER_API_KEY",
+    },
+}
+
+
+JsonLoader = Callable[[Path], Dict[str, Any]]
+JsonWriter = Callable[[Path, Dict[str, Any]], None]
+EnsureConfigFn = Callable[[Path], Dict[str, Any]]
+NormalizeConfigFn = Callable[[Dict[str, Any]], Dict[str, Any]]
+LinkProfileFn = Callable[[Path, str, str, str, Path], int]
+ReadLinkedCredentialFn = Callable[[Dict[str, Any]], Tuple[Optional[Dict[str, Any]], str]]
+IsExpiredFn = Callable[[Dict[str, Any]], bool]
+
+
+def resolve_codex_auth_path(override_path: Optional[str], default_codex_auth_path: Path) -> Path:
+    if override_path:
+        return Path(override_path).expanduser()
+    return default_codex_auth_path
+
+
+def resolve_gaia_auth_store(
+    cfg_path: Path,
+    override_path: Optional[str],
+    default_gaia_auth_store: Path,
+    load_json: JsonLoader,
+) -> Path:
+    if override_path:
+        return Path(override_path).expanduser()
+    cfg = load_json(cfg_path)
+    if cfg:
+        store = cfg.get("auth", {}).get("store_path")
+        if isinstance(store, str) and store.strip():
+            return Path(store).expanduser()
+    return default_gaia_auth_store
+
+
+def load_gaia_auth_store(path: Path, load_json: JsonLoader) -> Dict[str, Any]:
+    payload = load_json(path)
+    if not payload:
+        return {"version": 1, "profiles": {}}
+    if not isinstance(payload.get("profiles"), dict):
+        payload["profiles"] = {}
+    if "version" not in payload:
+        payload["version"] = 1
+    return payload
+
+
+def save_gaia_auth_store(path: Path, payload: Dict[str, Any], write_secret_json: JsonWriter) -> None:
+    write_secret_json(path, payload)
+
+
+def decode_jwt_payload(token: str) -> Dict[str, Any]:
+    parts = token.split(".")
+    if len(parts) < 2:
+        return {}
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(payload.encode("ascii")).decode("utf-8")
+        claims = json.loads(raw)
+        return claims if isinstance(claims, dict) else {}
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError):
+        return {}
+
+
+def read_codex_cli_credentials(codex_auth_path: Path, load_json: JsonLoader) -> Optional[Dict[str, Any]]:
+    payload = load_json(codex_auth_path)
+    if not payload:
+        return None
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, dict):
+        return None
+
+    access = tokens.get("access_token")
+    refresh = tokens.get("refresh_token")
+    account_id = tokens.get("account_id")
+    if not isinstance(access, str) or not access.strip():
+        return None
+    if not isinstance(refresh, str) or not refresh.strip():
+        return None
+
+    claims = decode_jwt_payload(access)
+    exp_s = claims.get("exp")
+    expires_ms: int
+    if isinstance(exp_s, (int, float)):
+        expires_ms = int(exp_s * 1000)
+    else:
+        expires_ms = int(datetime.now(timezone.utc).timestamp() * 1000) + 3600 * 1000
+
+    profile_claims = claims.get("https://api.openai.com/profile")
+    email = ""
+    if isinstance(profile_claims, dict):
+        raw_email = profile_claims.get("email")
+        if isinstance(raw_email, str):
+            email = raw_email.strip()
+
+    auth_claims = claims.get("https://api.openai.com/auth")
+    if not account_id and isinstance(auth_claims, dict):
+        auth_account_id = auth_claims.get("chatgpt_account_id")
+        if isinstance(auth_account_id, str) and auth_account_id.strip():
+            account_id = auth_account_id.strip()
+
+    return {
+        "type": "oauth",
+        "provider": "openai-codex",
+        "access": access,
+        "refresh": refresh,
+        "expires": expires_ms,
+        "account_id": str(account_id).strip() if isinstance(account_id, str) else "",
+        "email": email,
+        "source": "codex-cli",
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def is_expired(credential: Dict[str, Any]) -> bool:
+    expires = credential.get("expires")
+    if not isinstance(expires, (int, float)):
+        return False
+    return int(expires) <= int(datetime.now(timezone.utc).timestamp() * 1000)
+
+
+def format_expiry(credential: Dict[str, Any]) -> str:
+    expires = credential.get("expires")
+    if not isinstance(expires, (int, float)):
+        return "unknown"
+    try:
+        dt = datetime.fromtimestamp(int(expires) / 1000, tz=timezone.utc)
+        return dt.isoformat()
+    except (OSError, ValueError):
+        return "unknown"
+
+
+def profile_id_for_credential(provider: str, credential: Dict[str, Any]) -> str:
+    email = credential.get("email")
+    if isinstance(email, str) and email.strip():
+        return f"{provider}:{email.strip().lower()}"
+    account_id = credential.get("account_id")
+    if isinstance(account_id, str) and account_id.strip():
+        return f"{provider}:{account_id.strip()}"
+    return f"{provider}:default"
+
+
+def can_auto_align_codex_runtime_defaults(
+    cfg: Dict[str, Any],
+    default_anthropic_model: str,
+    normalize_bool_default: Callable[[Any, bool], bool],
+) -> bool:
+    reasoning = cfg.get("reasoning", {})
+    reasoning = reasoning if isinstance(reasoning, dict) else {}
+    profile = cfg.get("profile", {})
+    profile = profile if isinstance(profile, dict) else {}
+
+    if normalize_bool_default(reasoning.get("explicit_provider_override", False), False):
+        return False
+
+    current_provider = str(reasoning.get("provider", "")).strip().lower()
+    current_model = str(reasoning.get("model", "")).strip()
+    current_profile_provider = str(profile.get("default_provider", "")).strip().lower()
+
+    has_provider_override = current_provider not in ("", "anthropic")
+    has_model_override = bool(current_model and current_model != default_anthropic_model)
+    has_profile_provider_override = current_profile_provider not in ("", "anthropic", "openai-codex")
+    return not (has_provider_override or has_model_override or has_profile_provider_override)
+
+
+def apply_oauth_runtime_defaults(
+    cfg_path: Path,
+    oauth_provider: str,
+    *,
+    ensure_config_exists: EnsureConfigFn,
+    normalize_config: NormalizeConfigFn,
+    write_json: JsonWriter,
+    default_anthropic_model: str,
+    default_openai_model: str,
+    normalize_bool_default: Callable[[Any, bool], bool],
+) -> bool:
+    if oauth_provider != "openai-codex":
+        return False
+
+    cfg = ensure_config_exists(cfg_path)
+    if not can_auto_align_codex_runtime_defaults(cfg, default_anthropic_model, normalize_bool_default):
+        return False
+
+    reasoning = cfg.setdefault("reasoning", {})
+    if not isinstance(reasoning, dict):
+        reasoning = {}
+        cfg["reasoning"] = reasoning
+    profile = cfg.setdefault("profile", {})
+    if not isinstance(profile, dict):
+        profile = {}
+        cfg["profile"] = profile
+
+    changed = False
+    if str(reasoning.get("provider", "")).strip().lower() != "openai":
+        reasoning["provider"] = "openai"
+        changed = True
+
+    existing_model = str(reasoning.get("model", "")).strip()
+    if not existing_model or existing_model == default_anthropic_model:
+        if existing_model != default_openai_model:
+            reasoning["model"] = default_openai_model
+            changed = True
+
+    profile_provider = str(profile.get("default_provider", "")).strip().lower()
+    if profile_provider in ("", "anthropic", "openai-codex") and profile_provider != "openai":
+        profile["default_provider"] = "openai"
+        changed = True
+
+    if changed:
+        reasoning["explicit_provider_override"] = False
+        write_json(cfg_path, normalize_config(cfg))
+    return changed
+
+
+def import_codex_profile_to_gaia(
+    cfg_path: Path,
+    provider: str,
+    codex_auth_path: Path,
+    gaia_auth_store: Path,
+    *,
+    read_codex_cli_credentials_fn: Callable[[Path], Optional[Dict[str, Any]]],
+    load_gaia_auth_store_fn: Callable[[Path], Dict[str, Any]],
+    save_gaia_auth_store_fn: Callable[[Path, Dict[str, Any]], None],
+    link_profile_fn: LinkProfileFn,
+    apply_oauth_runtime_defaults_fn: Callable[[Path, str], bool],
+) -> Tuple[int, str, bool]:
+    if provider != "openai-codex":
+        return 1, "", False
+    credential = read_codex_cli_credentials_fn(codex_auth_path)
+    if credential is None:
+        return 1, "", False
+
+    store = load_gaia_auth_store_fn(gaia_auth_store)
+    profiles = store.setdefault("profiles", {})
+    if not isinstance(profiles, dict):
+        profiles = {}
+        store["profiles"] = profiles
+
+    profile_id = profile_id_for_credential(provider, credential)
+    profiles[profile_id] = credential
+    save_gaia_auth_store_fn(gaia_auth_store, store)
+    link_profile_fn(cfg_path, provider, profile_id, "gaia-local", gaia_auth_store)
+    runtime_aligned = apply_oauth_runtime_defaults_fn(cfg_path, provider)
+    return 0, profile_id, runtime_aligned
+
+
+def read_linked_credential(
+    active_profile: Dict[str, Any],
+    load_gaia_auth_store_fn: Callable[[Path], Dict[str, Any]],
+) -> Tuple[Optional[Dict[str, Any]], str]:
+    source = str(active_profile.get("source", "")).strip()
+    provider = str(active_profile.get("provider", "")).strip()
+    profile_id = str(active_profile.get("profile_id", "")).strip()
+    store_raw = str(active_profile.get("store_path", "")).strip()
+    if not store_raw:
+        return None, "linked profile store_path is empty"
+
+    store_path = Path(store_raw).expanduser()
+    if not store_path.exists():
+        return None, f"linked profile store not found: {store_path}"
+
+    if source == "gaia-local":
+        profiles = load_gaia_auth_store_fn(store_path).get("profiles", {})
+    else:
+        return None, f"unknown auth source: {source}"
+
+    if not isinstance(profiles, dict):
+        return None, f"profile store is invalid: {store_path}"
+
+    credential = profiles.get(profile_id)
+    if not isinstance(credential, dict):
+        return None, f"linked profile missing in store: {profile_id} ({store_path})"
+
+    if provider and credential.get("provider") != provider:
+        return None, (
+            f"linked profile provider mismatch for {profile_id}: "
+            f"expected {provider}, got {credential.get('provider')}"
+        )
+
+    return credential, ""
+
+
+def linked_openai_oauth_access_token(
+    cfg: Dict[str, Any],
+    *,
+    read_linked_credential_fn: ReadLinkedCredentialFn,
+    is_expired_fn: IsExpiredFn,
+) -> Tuple[str, str]:
+    auth_cfg = cfg.get("auth", {})
+    auth_cfg = auth_cfg if isinstance(auth_cfg, dict) else {}
+    active_profile = auth_cfg.get("active_profile")
+    if not isinstance(active_profile, dict):
+        return "", "no linked OAuth profile in launcher config"
+
+    provider = str(active_profile.get("provider", "")).strip().lower()
+    if provider != "openai-codex":
+        return "", "linked profile is not openai-codex"
+
+    credential, error = read_linked_credential_fn(active_profile)
+    if credential is None:
+        return "", error
+    if is_expired_fn(credential):
+        return "", "linked OAuth profile is expired"
+
+    access_token = str(credential.get("access", "")).strip()
+    if not access_token:
+        return "", "linked OAuth profile access token is missing"
+    return access_token, ""
+
+
+def provider_runtime_dependency_issue(provider: str, env: Dict[str, str]) -> Optional[str]:
+    normalized = str(provider).strip().lower()
+    if normalized == "anthropic":
+        if importlib.util.find_spec("anthropic") is None:
+            return "anthropic-package"
+        if not env.get("ANTHROPIC_API_KEY", "").strip():
+            return "anthropic-key"
+        return None
+    if normalized == "openai":
+        if not env.get("OPENAI_API_KEY", "").strip():
+            return "openai-key"
+        return None
+    if normalized == "openrouter":
+        if not env.get("OPENROUTER_API_KEY", "").strip():
+            return "openrouter-key"
+        return None
+    return "unsupported-provider"


### PR DESCRIPTION
## Summary
- extract onboarding/auth provider-registry and profile-link helper logic from `tools/gaia-assistant.py` into new module `tools/gaia_assistant_onboarding.py`
- keep CLI/parser command surfaces unchanged by using thin wrapper delegation in `tools/gaia-assistant.py`
- preserve and centralize auth/runtime helper flows (Codex OAuth credential parsing, linked profile lookup, runtime token availability, provider dependency preflight helpers)
- update npm packaging to include the extracted module and update architecture/assistant docs with the new boundary
- sync sprint state docs: move `#131` to In Progress and reflect merged `#134` in shipped list

Closes #131

Main role declaration: `contributor` (autonomous mode)

## Track Declaration
- [ ] `assistant-track`
- [ ] `framework-track`
- [x] Cross-track (`assistant-track` + `framework-track`)

## Risk Level
- [ ] Low
- [ ] Medium
- [x] High (requires explicit maintainer review before merge)

## Self-Evolution Applicability
- [ ] Applies: this PR changes self-evolution behavior/governance.
- [x] Not applicable: no self-evolution behavior/governance changes.

## Self-Evolution Evidence (required when applicability is "Applies")
- Baseline evidence: n/a
- Delta observed: n/a
- Thresholds and guardrails: n/a
- Rollback/fallback: n/a
- Risk notes: n/a

## Validation
- [x] `make check-all`
- [x] `make test-smoke` (if assistant/runtime behavior changed)
- [x] `make test-uat` (required for assistant feature changes)
- [x] Additional targeted checks documented below

Additional targeted checks:
- `python3 -m py_compile tools/gaia-assistant.py tools/gaia_assistant_parser.py tools/gaia_assistant_onboarding.py tools/agent-loop.py`
- `make uat-policy`
- `python3 tools/uat-runner.py --run onboard_openai_nostore --run auth_status_command --run auth_link_codex_missing_credentials --run auth_link_codex_aligns_run_provider --run run_single_dry`

## Checklist
- [x] Changes are small, safe, and incremental
- [x] No breaking changes to structure or website
- [x] Docs follow repo markdown standards
- [x] Links added/updated were verified
- [x] Track and risk are declared
- [x] Self-evolution applicability declared and rubric completed when required
- [x] Handoff notes included (files changed, validations, follow-ups)
- [x] New feature surfaces include UAT updates in this PR

## UAT Change Justification
- Not applicable: protected UAT governance files were not modified.

## Notes
- Sub-role gate evidence posted on issue `#131`:
  - `gaia-security-reviewer`: https://github.com/Gaia-minds/gaia-minds/issues/131#issuecomment-3904090003
  - `gaia-qa-evaluator`: https://github.com/Gaia-minds/gaia-minds/issues/131#issuecomment-3904091012
- Main file complexity reduction:
  - `tools/gaia-assistant.py` line count reduced from `12525` (`origin/main`) to `12317`
  - onboarding/auth helper logic relocated to `tools/gaia_assistant_onboarding.py`
- State docs:
  - `STATUS.md` updated for queue/in-progress/shipped state alignment
  - `ROADMAP.md` no-change reason: lane ordering/dependency model unchanged
  - `CHANGELOG.md` no-change reason: active sprint status tracked in `STATUS.md`; shipped log update can be rolled into sprint closeout/merge cadence
- Architecture delta documented in `infrastructure/architecture.md`.
