### PR TITLE
feat(assistant): add provider model catalog inspection command

### DIFF
--- a/assistant/README.md
+++ b/assistant/README.md
@@ -104,6 +104,19 @@ are available (OpenAI, Anthropic, OpenRouter) and falls back to a curated list
 when live catalog retrieval is not possible (for example Codex/Claude CLI-only
 OAuth flows). You can always bypass prompts with `--model <model-id>`.
 
+To inspect model catalogs before onboarding or config changes:
+
+```bash
+# List one provider with source disclosure
+gaia models list --provider openai-codex
+
+# Machine-readable output
+gaia models list --provider openai-codex --json
+
+# Inspect all supported providers
+gaia models list
+```
+
 Direct non-interactive examples:
 
 ```bash

--- a/assistant/feature-catalog.json
+++ b/assistant/feature-catalog.json
@@ -4,6 +4,8 @@
   "commands": [
     {"path": "init", "scenarios": ["init_force"]},
     {"path": "onboard", "scenarios": ["onboard_openai_nostore", "onboard_claude_code_oauth"]},
+    {"path": "models", "scenarios": ["models_list_source_disclosure"]},
+    {"path": "models list", "scenarios": ["models_list_source_disclosure"]},
     {"path": "doctor", "scenarios": ["doctor_command"]},
     {"path": "config", "scenarios": ["cli_help_surface"]},
     {"path": "config set", "scenarios": ["config_set_get_name", "provider_twin_openai", "signals_extraction_privacy_controls", "signals_skill_first_triage_matrix", "skills_provenance_admission_modes", "skills_obfuscation_validation_hardening"]},

--- a/assistant/uat-scenarios.json
+++ b/assistant/uat-scenarios.json
@@ -28,6 +28,12 @@
       "command": "python3 -c 'import os, pathlib; p = pathlib.Path(os.environ[\"GAIA_ASSISTANT_HOME\"]) / \"tmp-bin\" / \"claude\"; p.parent.mkdir(parents=True, exist_ok=True); p.write_text(\"#!/usr/bin/env bash\\nset -euo pipefail\\nif [[ \\\"${1:-}\\\" == \\\"auth\\\" && \\\"${2:-}\\\" == \\\"login\\\" ]]; then\\n  exit 0\\nfi\\nif [[ \\\"${1:-}\\\" == \\\"auth\\\" && \\\"${2:-}\\\" == \\\"status\\\" && \\\"${3:-}\\\" == \\\"--json\\\" ]]; then\\n  printf \\\"%s\\\\n\\\" \\\"{\\\\\\\"authenticated\\\\\\\": true, \\\\\\\"email\\\\\\\": \\\\\\\"claude-uat@example.com\\\\\\\", \\\\\\\"account_id\\\\\\\": \\\\\\\"claude-uat-account\\\\\\\", \\\\\\\"organization\\\\\\\": \\\\\\\"gaia-minds\\\\\\\", \\\\\\\"plan\\\\\\\": \\\\\\\"pro\\\\\\\"}\\\"\\n  exit 0\\nfi\\necho \\\"unexpected args: $*\\\" >&2\\nexit 1\\n\", encoding=\"utf-8\"); p.chmod(0o755)' && PATH=\"$GAIA_ASSISTANT_HOME/tmp-bin:$PATH\" node ./bin/gaia.js onboard --provider claude-code --yes >/dev/null && status_out=$(node ./bin/gaia.js auth status) && [[ \"$status_out\" == *\"provider:  claude-code\"* ]] && [[ \"$status_out\" == *\"email:     claude-uat@example.com\"* ]]"
     },
     {
+      "id": "models_list_source_disclosure",
+      "description": "Model catalog inspection emits provider source provenance in text and JSON output",
+      "expect_exit": 0,
+      "command": "json=$(node ./bin/gaia.js models list --provider openai-codex --json) && source=$(printf '%s' \"$json\" | python3 -c \"import json,sys; payload=json.load(sys.stdin); print(payload.get('source', ''))\") && [[ \"$source\" == \"live\" || \"$source\" == \"curated\" ]] && model0=$(printf '%s' \"$json\" | python3 -c \"import json,sys; payload=json.load(sys.stdin); models=payload.get('models', []); print(models[0] if models else '')\") && [[ \"$model0\" == \"gpt-5.3-codex\" ]] && text=$(node ./bin/gaia.js models list --provider openai-codex) && [[ \"$text\" == *\"provider: openai-codex\"* ]] && [[ \"$text\" == *\"source:\"* ]]"
+    },
+    {
       "id": "doctor_command",
       "description": "Doctor command runs without blocking errors",
       "expect_exit": 0,

--- a/docs/uat-changes/2026-02-15-model-catalog-inspection-command.md
+++ b/docs/uat-changes/2026-02-15-model-catalog-inspection-command.md
@@ -1,0 +1,43 @@
+# Model Catalog Inspection Command UAT Update (2026-02-15)
+
+## Why this change
+
+Issue `#145` introduces a new assistant command surface:
+
+- `gaia models list`
+
+Because this adds a new CLI command path, protected UAT policy files were
+updated to register deterministic coverage for:
+
+- `models`
+- `models list`
+
+New scenario:
+
+- `models_list_source_disclosure`
+
+This scenario validates both text and JSON output contracts, including
+provider/source disclosure and deterministic default ordering for the
+`openai-codex` provider path.
+
+## Risk
+
+- Medium.
+- Main risk is command-surface drift: parser path additions without UAT mapping
+  can silently regress policy coverage and break downstream command contracts.
+
+## Confidence and Safeguards
+
+- The UAT scenario is deterministic and does not require external credentials.
+- Assertions validate source disclosure (`live` or `curated`) rather than
+  brittle provider-network assumptions.
+- JSON output is parsed with Python to ensure schema-level correctness instead
+  of substring-only checks.
+
+## Validation
+
+- `python3 -m py_compile tools/gaia-assistant.py tools/gaia_assistant_parser.py tools/gaia_assistant_onboarding.py`
+- `make test-smoke`
+- `make test-uat`
+- `make check-all`
+- `python3 tools/check-uat-policy.py --base-ref origin/main --reviewer TonyThePredictor`

--- a/tools/gaia-assistant.py
+++ b/tools/gaia-assistant.py
@@ -4570,6 +4570,16 @@ def _fetch_openrouter_free_models(api_key: str) -> List[str]:
     return _dedupe_models(sorted(free))
 
 
+def _provider_catalog_api_key_env_var(provider: str) -> str:
+    return {
+        "openrouter": "OPENROUTER_API_KEY",
+        "openai": "OPENAI_API_KEY",
+        "openai-codex": "OPENAI_API_KEY",
+        "anthropic": "ANTHROPIC_API_KEY",
+        "claude-code": "ANTHROPIC_API_KEY",
+    }.get(provider, "")
+
+
 def _seed_api_key_for_provider(
     cfg_path: Path,
     provider: str,
@@ -4579,13 +4589,7 @@ def _seed_api_key_for_provider(
     provided = explicit_api_key.strip() if isinstance(explicit_api_key, str) else ""
     if provided:
         return provided
-    env_var = {
-        "openrouter": "OPENROUTER_API_KEY",
-        "openai": "OPENAI_API_KEY",
-        "openai-codex": "OPENAI_API_KEY",
-        "anthropic": "ANTHROPIC_API_KEY",
-        "claude-code": "ANTHROPIC_API_KEY",
-    }.get(provider, "")
+    env_var = _provider_catalog_api_key_env_var(provider)
     if not env_var:
         return ""
     env_value = os.environ.get(env_var, "").strip()
@@ -4629,6 +4633,56 @@ def _provider_model_catalog(provider: str, api_key: str) -> Tuple[List[str], str
     return fallback, "curated catalog"
 
 
+def _provider_model_catalog_snapshot(
+    provider: str,
+    *,
+    cfg_path: Path,
+    explicit_api_key: Optional[str],
+    secret_store_override: Optional[str],
+) -> Dict[str, Any]:
+    seed_key = _seed_api_key_for_provider(
+        cfg_path=cfg_path,
+        provider=provider,
+        explicit_api_key=explicit_api_key,
+        secret_store_override=secret_store_override,
+    )
+    catalog, source_detail = _provider_model_catalog(provider, seed_key)
+    source = "live" if source_detail.startswith("live") else "curated"
+    default_model = _default_model_for_provider(provider)
+    ordered_models = _dedupe_models([default_model, *catalog], limit=PROVIDER_MODEL_CATALOG_LIMIT)
+    fallback_reason = ""
+    guidance = ""
+
+    if source != "live":
+        env_var = _provider_catalog_api_key_env_var(provider)
+        if seed_key:
+            fallback_reason = "live_catalog_unavailable"
+            guidance = (
+                "Live catalog request failed or returned no eligible models. "
+                "Check credential scope, quota, and network connectivity."
+            )
+        else:
+            fallback_reason = "missing_credentials"
+            if env_var:
+                guidance = (
+                    f"No API key detected for live catalog discovery. "
+                    f"Set {env_var} or pass --api-key with --provider."
+                )
+            else:
+                guidance = "No live-catalog credential path is configured for this provider."
+
+    return {
+        "provider": provider,
+        "provider_display_name": PROVIDER_DISPLAY_NAMES.get(provider, provider),
+        "source": source,
+        "source_detail": source_detail,
+        "fallback_reason": fallback_reason,
+        "guidance": guidance,
+        "default_model": default_model,
+        "models": ordered_models,
+    }
+
+
 def _select_provider_model(
     provider: str,
     *,
@@ -4641,14 +4695,15 @@ def _select_provider_model(
     if explicit_model and explicit_model.strip():
         return explicit_model.strip()
 
-    default_model = _default_model_for_provider(provider)
-    seed_key = _seed_api_key_for_provider(
+    snapshot = _provider_model_catalog_snapshot(
+        provider,
         cfg_path=cfg_path,
-        provider=provider,
         explicit_api_key=explicit_api_key,
         secret_store_override=secret_store_override,
     )
-    catalog, source = _provider_model_catalog(provider, seed_key)
+    default_model = str(snapshot.get("default_model", _default_model_for_provider(provider)))
+    catalog = [str(item).strip() for item in snapshot.get("models", []) if str(item).strip()]
+    source = str(snapshot.get("source_detail", "curated catalog"))
 
     if source.startswith("live"):
         print(f"[ok] loaded provider model catalog ({source})")
@@ -4908,6 +4963,59 @@ def _linked_openai_oauth_access_token(cfg: Dict[str, Any]) -> Tuple[str, str]:
 
 def _provider_runtime_dependency_issue(provider: str, env: Dict[str, str]) -> Optional[str]:
     return onboarding.provider_runtime_dependency_issue(provider, env)
+
+
+def cmd_models_list(args: argparse.Namespace) -> int:
+    cfg_path = Path(args.config).expanduser()
+    provider_filter = str(args.provider).strip() if isinstance(args.provider, str) else ""
+    explicit_api_key = str(args.api_key).strip() if isinstance(args.api_key, str) else ""
+    if explicit_api_key and not provider_filter:
+        print("--api-key requires --provider to disambiguate target catalog.", file=sys.stderr)
+        return 1
+
+    providers = [provider_filter] if provider_filter else list(ONBOARD_PROVIDER_CHOICES)
+    payload: List[Dict[str, Any]] = []
+    for provider in providers:
+        snapshot = _provider_model_catalog_snapshot(
+            provider,
+            cfg_path=cfg_path,
+            explicit_api_key=explicit_api_key if provider == provider_filter else None,
+            secret_store_override=args.secret_store,
+        )
+        payload.append(snapshot)
+
+    if args.as_json:
+        if provider_filter and payload:
+            print(json.dumps(payload[0], indent=2))
+        else:
+            print(json.dumps({"providers": payload}, indent=2))
+        return 0
+
+    print("Provider model catalogs")
+    print("=======================")
+    for idx, entry in enumerate(payload):
+        if idx:
+            print("")
+        provider = str(entry.get("provider", ""))
+        provider_label = str(entry.get("provider_display_name", provider))
+        source = str(entry.get("source", "curated"))
+        source_detail = str(entry.get("source_detail", "curated catalog"))
+        fallback_reason = str(entry.get("fallback_reason", "")).strip()
+        guidance = str(entry.get("guidance", "")).strip()
+        default_model = str(entry.get("default_model", "")).strip()
+        models = [str(item).strip() for item in entry.get("models", []) if str(item).strip()]
+
+        print(f"provider: {provider} ({provider_label})")
+        print(f"source:   {source} ({source_detail})")
+        if fallback_reason:
+            print(f"reason:   {fallback_reason}")
+        if guidance:
+            print(f"guidance: {guidance}")
+        print("models:")
+        for model in models:
+            marker = " (recommended)" if model == default_model else ""
+            print(f"  - {model}{marker}")
+    return 0
 
 
 def cmd_init(args: argparse.Namespace) -> int:

--- a/tools/gaia_assistant_parser.py
+++ b/tools/gaia_assistant_parser.py
@@ -62,6 +62,7 @@ def build_parser(ctx: Dict[str, Any]) -> argparse.ArgumentParser:
     cmd_memory_retrieve = ctx["cmd_memory_retrieve"]
     cmd_memory_summarize = ctx["cmd_memory_summarize"]
     cmd_memory_update = ctx["cmd_memory_update"]
+    cmd_models_list = ctx["cmd_models_list"]
     cmd_note = ctx["cmd_note"]
     cmd_onboard = ctx["cmd_onboard"]
     cmd_plan = ctx["cmd_plan"]
@@ -150,6 +151,30 @@ def build_parser(ctx: Dict[str, Any]) -> argparse.ArgumentParser:
     )
     onboard.add_argument("--yes", action="store_true", help="Skip onboarding confirmations")
     onboard.set_defaults(func=cmd_onboard)
+
+    models = sub.add_parser("models", help="Inspect provider model catalogs")
+    models_sub = models.add_subparsers(dest="models_command", required=True)
+
+    models_list = models_sub.add_parser("list", help="List provider model options with source provenance")
+    models_list.add_argument("--config", default=str(DEFAULT_CONFIG_PATH), help="Config JSON path")
+    models_list.add_argument(
+        "--secret-store",
+        default=None,
+        help="Path to local secrets.json store (optional override)",
+    )
+    models_list.add_argument(
+        "--provider",
+        choices=list(ONBOARD_PROVIDER_CHOICES),
+        default=None,
+        help="Provider to inspect (all providers when omitted)",
+    )
+    models_list.add_argument(
+        "--api-key",
+        default=None,
+        help="Optional API key override (requires --provider)",
+    )
+    models_list.add_argument("--json", dest="as_json", action="store_true", help="Emit JSON output")
+    models_list.set_defaults(func=cmd_models_list)
 
     doctor = sub.add_parser("doctor", help="Validate local environment and auth readiness")
     doctor.add_argument("--config", default=str(DEFAULT_CONFIG_PATH), help="Config JSON path")


### PR DESCRIPTION
## Summary
- add `gaia models list` command surface with provider filter and machine-readable JSON output
- reuse existing provider catalog resolution logic so onboarding and inspection share live-vs-curated behavior
- expose explicit source provenance (`live` / `curated`), fallback reason, and provider-specific credential guidance
- update UAT mappings/scenarios and document protected UAT-file change rationale

## Track Declaration
- [x] `assistant-track`
- [ ] `framework-track`
- [ ] Cross-track (`assistant-track` + `framework-track`)

## Risk Level
- [ ] Low
- [x] Medium
- [ ] High (requires explicit maintainer review before merge)

## Self-Evolution Applicability
- [ ] Applies: this PR changes self-evolution behavior/governance.
- [x] Not applicable: no self-evolution behavior/governance changes.

## Self-Evolution Evidence (required when applicability is "Applies")
- Baseline evidence: N/A
- Delta observed: N/A
- Thresholds and guardrails: N/A
- Rollback/fallback: N/A
- Risk notes: N/A

## Validation
- [x] `make check-all`
- [x] `make test-smoke` (if assistant/runtime behavior changed)
- [x] `make test-uat` (required for assistant feature changes)
- [x] Additional targeted checks documented below

Additional targeted checks:
- `python3 -m py_compile tools/gaia-assistant.py tools/gaia_assistant_parser.py tools/gaia_assistant_onboarding.py`
- `python3 tools/check-uat-policy.py --base-ref origin/main --reviewer TonyThePredictor`

## Checklist
- [x] Changes are small, safe, and incremental
- [x] No breaking changes to structure or website
- [x] Docs follow repo markdown standards
- [x] Links added/updated were verified
- [x] Track and risk are declared
- [x] Self-evolution applicability declared and rubric completed when required
- [x] Handoff notes included (files changed, validations, follow-ups)
- [x] New feature surfaces include UAT updates in this PR

## UAT Change Justification
This PR introduces a new command surface (`models` + `models list`), which requires protected UAT governance files (`assistant/feature-catalog.json` and `assistant/uat-scenarios.json`) to change in lockstep so CI can enforce command-to-scenario coverage deterministically. Without this update, the UAT policy gate correctly fails and new runtime behavior can drift from documented guarantees. The added scenario asserts both human-readable and JSON contract behavior for provider/source disclosure and default model ordering in a deterministic, credential-agnostic way, which keeps confidence high while avoiding brittle external network assumptions.

## Notes
- Files changed:
  - `tools/gaia-assistant.py`
  - `tools/gaia_assistant_parser.py`
  - `assistant/feature-catalog.json`
  - `assistant/uat-scenarios.json`
  - `assistant/README.md`
  - `docs/uat-changes/2026-02-15-model-catalog-inspection-command.md`
- No architecture delta.
- State-doc sync:
  - `STATUS.md`: no change (issue-level progress tracked in issue/PR workflow)
  - `ROADMAP.md`: no change (no sequencing/priority delta)
  - `CHANGELOG.md`: no change (batch in maintainer release notes flow)

Closes #145
