### PR TITLE
feat(runtime): deterministic reasoning failover on hard errors

### DIFF
--- a/assistant/README.md
+++ b/assistant/README.md
@@ -826,6 +826,18 @@ npm run gaia -- run --mode single --reasoning-provider openai --reasoning-model 
 npm run gaia -- run --mode single --reasoning-provider openrouter --reasoning-model openrouter/auto
 ```
 
+Runtime hard-error failover:
+
+- Gaia now supports deterministic failover across providers on configured hard
+  error classes (`quota`, `auth`), including `insufficient_quota`-style
+  failures.
+- Default order is `openai -> openrouter -> anthropic` (excluding the active
+  provider).
+- `gaia run` prints failover policy details at startup and agent-loop logs
+  explicit trigger/attempt/success-or-exhausted events.
+- Launcher config path: `reasoning.failover` in `~/.gaia-assistant/config.json`
+  (`enabled`, `hard_error_classes`, `order`, `models`).
+
 OpenRouter quick setup:
 
 ```bash

--- a/assistant/feature-catalog.json
+++ b/assistant/feature-catalog.json
@@ -72,7 +72,7 @@
     {"path": "auth login", "scenarios": ["auth_login_unsupported_provider", "auth_login_claude_cli_source"]},
     {"path": "auth link", "scenarios": ["auth_link_rejects_openclaw_source", "auth_link_codex_missing_credentials"]},
     {"path": "auth status", "scenarios": ["auth_status_command", "auth_login_claude_cli_source"]},
-    {"path": "run", "scenarios": ["run_single_dry"]}
+    {"path": "run", "scenarios": ["run_single_dry", "run_failover_quota_hard_error"]}
   ],
   "agent_actions": [
     {"type": "verify_resources", "scenarios": ["agent_loop_dry_run"]},

--- a/assistant/uat-scenarios.json
+++ b/assistant/uat-scenarios.json
@@ -280,6 +280,12 @@
       "command": "node ./bin/gaia.js run --mode single --dry-run --reasoning-provider openai --reasoning-model gpt-4.1-mini >/dev/null"
     },
     {
+      "id": "run_failover_quota_hard_error",
+      "description": "Gaia run applies deterministic provider failover on quota hard errors with visible logs",
+      "expect_exit": 0,
+      "command": "bash ./tools/runtime-failover-check.sh"
+    },
+    {
       "id": "agent_loop_dry_run",
       "description": "Self-evolve loop dry-run command path works",
       "expect_exit": 0,

--- a/docs/uat-changes/2026-02-15-runtime-failover-hard-error-coverage.md
+++ b/docs/uat-changes/2026-02-15-runtime-failover-hard-error-coverage.md
@@ -1,0 +1,43 @@
+# Runtime Failover Hard-Error Coverage UAT Update (2026-02-15)
+
+## Why this change
+
+Issue `#146` adds runtime failover behavior for reasoning-provider hard errors
+(quota/auth classes). This lane updates protected UAT governance files to keep
+command-to-scenario coverage deterministic for the `run` command path.
+
+Updated mapping:
+
+- `run` now includes `run_failover_quota_hard_error`.
+
+New scenario:
+
+- `run_failover_quota_hard_error`
+
+The new scenario uses deterministic local mock provider endpoints to force an
+OpenAI-style `insufficient_quota` failure and verify failover visibility and
+successful fallback to OpenRouter behavior.
+
+## Risk
+
+- High.
+- Runtime failover changes provider-selection behavior during live runs; missing
+  UAT coverage could hide regressions in fallback ordering or failure handling.
+
+## Confidence and Safeguards
+
+- The failover scenario is fully local (no external network dependency) via
+  `tools/runtime-failover-check.sh` mock servers.
+- Assertions validate policy visibility (`Reasoning failover: enabled`),
+  trigger detection, and deterministic fallback success logging.
+- Existing `run_single_dry` coverage remains intact to preserve baseline run
+  command-path confidence.
+
+## Validation
+
+- `python3 -m py_compile tools/gaia-assistant.py tools/gaia_assistant_parser.py tools/gaia_assistant_onboarding.py tools/agent-loop.py`
+- `bash ./tools/runtime-failover-check.sh`
+- `make test-smoke`
+- `make test-uat`
+- `make check-all`
+- `python3 tools/check-uat-policy.py --base-ref origin/main --reviewer TonyThePredictor`

--- a/tools/agent-config.yml
+++ b/tools/agent-config.yml
@@ -28,6 +28,14 @@ reasoning:
     openrouter: "openrouter/auto"
   max_tokens: 4096
   temperature: 0.3  # low for consistent reasoning
+  failover:
+    enabled: true
+    hard_error_classes: ["quota", "auth"]
+    order: ["openai", "openrouter", "anthropic"]
+    models:
+      anthropic: "claude-sonnet-4-5-20250929"
+      openai: "gpt-4.1-mini"
+      openrouter: "openrouter/auto"
   openai:
     base_url: "https://api.openai.com/v1"
     timeout_seconds: 120

--- a/tools/agent-loop.py
+++ b/tools/agent-loop.py
@@ -130,6 +130,8 @@ DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-5-20250929"
 DEFAULT_OPENAI_MODEL = "gpt-4.1-mini"
 DEFAULT_OPENROUTER_MODEL = "openrouter/auto"
 SUPPORTED_REASONING_PROVIDERS = {"anthropic", "openai", "openrouter"}
+DEFAULT_REASONING_FAILOVER_ORDER = ("openai", "openrouter", "anthropic")
+DEFAULT_REASONING_FAILOVER_ERROR_CLASSES = ("quota", "auth")
 
 
 # ---------------------------------------------------------------------------
@@ -335,6 +337,139 @@ def _resolve_openrouter_runtime(config: Dict[str, Any]) -> Dict[str, Any]:
         "app_url": app_url,
         "timeout_seconds": timeout_seconds,
     }
+
+
+def _parse_bool_default(value: Any, default_value: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    token = str(value).strip().lower()
+    if token in {"1", "true", "yes", "on", "enabled"}:
+        return True
+    if token in {"0", "false", "no", "off", "disabled"}:
+        return False
+    return default_value
+
+
+def _resolve_reasoning_failover_policy(config: Dict[str, Any], primary_provider: str) -> Dict[str, Any]:
+    reasoning = config.get("reasoning", {})
+    reasoning = reasoning if isinstance(reasoning, dict) else {}
+    failover_cfg = reasoning.get("failover", {})
+    failover_cfg = failover_cfg if isinstance(failover_cfg, dict) else {}
+
+    enabled_default = _parse_bool_default(failover_cfg.get("enabled", True), True)
+    enabled = _parse_bool_default(os.environ.get("GAIA_REASONING_FAILOVER_ENABLED", ""), enabled_default)
+
+    classes_override = os.environ.get("GAIA_REASONING_FAILOVER_HARD_ERRORS", "").strip()
+    classes_raw: Any = classes_override if classes_override else failover_cfg.get(
+        "hard_error_classes",
+        list(DEFAULT_REASONING_FAILOVER_ERROR_CLASSES),
+    )
+    if isinstance(classes_raw, str):
+        class_tokens = [token.strip().lower() for token in classes_raw.split(",")]
+    elif isinstance(classes_raw, list):
+        class_tokens = [str(token).strip().lower() for token in classes_raw]
+    else:
+        class_tokens = list(DEFAULT_REASONING_FAILOVER_ERROR_CLASSES)
+    hard_error_classes: List[str] = []
+    for token in class_tokens:
+        if token in DEFAULT_REASONING_FAILOVER_ERROR_CLASSES and token not in hard_error_classes:
+            hard_error_classes.append(token)
+    if not hard_error_classes:
+        hard_error_classes = list(DEFAULT_REASONING_FAILOVER_ERROR_CLASSES)
+
+    order_override = os.environ.get("GAIA_REASONING_FAILOVER_ORDER", "").strip()
+    order_raw: Any = order_override if order_override else failover_cfg.get("order", list(DEFAULT_REASONING_FAILOVER_ORDER))
+    if isinstance(order_raw, str):
+        order_tokens = [token.strip().lower() for token in order_raw.split(",")]
+    elif isinstance(order_raw, list):
+        order_tokens = [str(token).strip().lower() for token in order_raw]
+    else:
+        order_tokens = list(DEFAULT_REASONING_FAILOVER_ORDER)
+    order: List[str] = []
+    for token in order_tokens:
+        if token in SUPPORTED_REASONING_PROVIDERS and token != primary_provider and token not in order:
+            order.append(token)
+
+    models_raw = failover_cfg.get("models", {})
+    models_raw = models_raw if isinstance(models_raw, dict) else {}
+    models: Dict[str, str] = {}
+    for provider in SUPPORTED_REASONING_PROVIDERS:
+        value = str(models_raw.get(provider, "")).strip()
+        if value:
+            models[provider] = value
+    models_override = os.environ.get("GAIA_REASONING_FAILOVER_MODELS", "").strip()
+    if models_override:
+        for token in models_override.split(","):
+            item = token.strip()
+            if not item or "=" not in item:
+                continue
+            provider, model = item.split("=", 1)
+            provider = provider.strip().lower()
+            model = model.strip()
+            if provider in SUPPORTED_REASONING_PROVIDERS and model:
+                models[provider] = model
+
+    return {
+        "enabled": enabled,
+        "hard_error_classes": hard_error_classes,
+        "order": order,
+        "models": models,
+    }
+
+
+def _classify_reasoning_error(error_text: str) -> str:
+    normalized = str(error_text).strip().lower()
+    if not normalized:
+        return "other"
+    quota_markers = (
+        "insufficient_quota",
+        "rate limit",
+        "quota",
+        "billing",
+        "http 429",
+    )
+    if any(marker in normalized for marker in quota_markers):
+        return "quota"
+    auth_markers = (
+        "http 401",
+        "http 403",
+        "unauthorized",
+        "forbidden",
+        "authentication",
+        "invalid api key",
+        "api key is not set",
+        "permission denied",
+    )
+    if any(marker in normalized for marker in auth_markers):
+        return "auth"
+    return "other"
+
+
+def _initialize_reasoning_client(
+    config: Dict[str, Any],
+    provider: str,
+    *,
+    model_override: str = "",
+) -> Tuple[Any, str, str]:
+    model = model_override.strip() or _resolve_reasoning_model(config, provider)
+    if provider == "anthropic":
+        if not _HAS_ANTHROPIC:
+            return None, model, "anthropic-package"
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+        if not api_key:
+            return None, model, "anthropic-key"
+        return anthropic.Anthropic(api_key=api_key), model, ""
+    if provider == "openai":
+        runtime = _resolve_openai_runtime(config)
+        if not runtime.get("api_key"):
+            return None, model, "openai-key"
+        return runtime, model, ""
+    if provider == "openrouter":
+        runtime = _resolve_openrouter_runtime(config)
+        if not runtime.get("api_key"):
+            return None, model, "openrouter-key"
+        return runtime, model, ""
+    return None, model, "unsupported-provider"
 
 
 # ---------------------------------------------------------------------------
@@ -1335,8 +1470,15 @@ def ask_model_for_plan(
         else:
             raise RuntimeError(f"Unsupported reasoning provider: {provider}")
     except Exception as exc:
+        error_text = str(exc)
+        error_class = _classify_reasoning_error(error_text)
         log.error("Reasoning request failed (%s/%s): %s", provider, model, exc)
-        return {"reasoning": f"Reasoning request failed: {exc}", "actions": []}
+        return {
+            "reasoning": f"Reasoning request failed: {exc}",
+            "actions": [],
+            "_reasoning_error": error_text,
+            "_reasoning_error_class": error_class,
+        }
 
     # Parse JSON from response text.
     text = _strip_markdown_fences(text)
@@ -1402,17 +1544,33 @@ def run_cycle(
     constitution = load_constitution(repo_root)
 
     # 4. Ask reasoning provider for a plan
+    failover_policy = _resolve_reasoning_failover_policy(config, reasoning_provider)
+    hard_error_classes = set(failover_policy.get("hard_error_classes", []))
+    failover_order = list(failover_policy.get("order", []))
+    failover_models = failover_policy.get("models", {})
+    failover_models = failover_models if isinstance(failover_models, dict) else {}
+    log.info(
+        "Reasoning failover policy: enabled=%s hard_errors=%s order=%s",
+        bool(failover_policy.get("enabled", False)),
+        ",".join(sorted(hard_error_classes)) or "(none)",
+        ",".join(failover_order) or "(none)",
+    )
+
+    failover_attempts: List[Dict[str, str]] = []
+    selected_provider = reasoning_provider
+    selected_model = reasoning_model
+
     if client is None:
         log.info(
-            "No API client available for provider '%s' -- skipping reasoning (dry-run)",
+            "No API client available for provider '%s' -- proceeding with failover policy evaluation",
             reasoning_provider,
         )
+        primary_error = f"No API client available for provider '{reasoning_provider}'"
         plan = {
-            "reasoning": (
-                f"No API client (dry-run without provider credentials), "
-                f"provider={reasoning_provider}, active_track={active_track}"
-            ),
+            "reasoning": f"Reasoning request failed: {primary_error}",
             "actions": [],
+            "_reasoning_error": primary_error,
+            "_reasoning_error_class": "auth",
         }
     else:
         plan = ask_model_for_plan(
@@ -1424,6 +1582,114 @@ def run_cycle(
             active_track=active_track,
             provider=reasoning_provider,
             model=reasoning_model,
+        )
+
+    primary_error = str(plan.get("_reasoning_error", "")).strip()
+    primary_error_class = str(plan.get("_reasoning_error_class", "other")).strip().lower()
+    if primary_error:
+        if dry_run:
+            log.info("Dry-run mode: skipping runtime failover after error class=%s", primary_error_class)
+        elif bool(failover_policy.get("enabled", False)) and primary_error_class in hard_error_classes:
+            log.warning(
+                "Reasoning failover triggered: provider=%s model=%s class=%s error=%s",
+                reasoning_provider,
+                reasoning_model,
+                primary_error_class,
+                primary_error,
+            )
+            for fallback_provider in failover_order:
+                model_override = str(failover_models.get(fallback_provider, "")).strip()
+                fallback_client, fallback_model, init_issue = _initialize_reasoning_client(
+                    config,
+                    fallback_provider,
+                    model_override=model_override,
+                )
+                attempt: Dict[str, str] = {
+                    "provider": fallback_provider,
+                    "model": fallback_model,
+                }
+                if fallback_client is None:
+                    attempt["outcome"] = "skipped"
+                    attempt["reason"] = init_issue or "client-unavailable"
+                    failover_attempts.append(attempt)
+                    log.warning(
+                        "Reasoning failover skipped %s/%s: %s",
+                        fallback_provider,
+                        fallback_model,
+                        init_issue or "client-unavailable",
+                    )
+                    continue
+
+                fallback_plan = ask_model_for_plan(
+                    client=fallback_client,
+                    config=config,
+                    state=state,
+                    memory=memory,
+                    constitution=constitution,
+                    active_track=active_track,
+                    provider=fallback_provider,
+                    model=fallback_model,
+                )
+                fallback_error = str(fallback_plan.get("_reasoning_error", "")).strip()
+                fallback_error_class = str(fallback_plan.get("_reasoning_error_class", "other")).strip().lower()
+                if fallback_error:
+                    attempt["outcome"] = "failed"
+                    attempt["reason"] = fallback_error_class or "other"
+                    failover_attempts.append(attempt)
+                    log.warning(
+                        "Reasoning failover attempt failed: %s/%s class=%s error=%s",
+                        fallback_provider,
+                        fallback_model,
+                        fallback_error_class or "other",
+                        fallback_error,
+                    )
+                    continue
+
+                attempt["outcome"] = "success"
+                attempt["reason"] = "ok"
+                failover_attempts.append(attempt)
+                plan = fallback_plan
+                selected_provider = fallback_provider
+                selected_model = fallback_model
+                log.info(
+                    "Reasoning failover succeeded: %s/%s -> %s/%s",
+                    reasoning_provider,
+                    reasoning_model,
+                    selected_provider,
+                    selected_model,
+                )
+                break
+
+            if failover_attempts and not any(item.get("outcome") == "success" for item in failover_attempts):
+                log.error(
+                    "Reasoning failover exhausted with no successful provider. "
+                    "Attempts=%s",
+                    failover_attempts,
+                )
+        elif not bool(failover_policy.get("enabled", False)):
+            log.info("Reasoning failover disabled; not attempting fallback after error class=%s", primary_error_class)
+        else:
+            log.info(
+                "Reasoning failover not applied for error class=%s (configured=%s)",
+                primary_error_class,
+                ",".join(sorted(hard_error_classes)) or "(none)",
+            )
+
+    if failover_attempts:
+        log_lesson(
+            cycle_number,
+            "Reasoning failover attempted",
+            "reasoning_failover",
+            json.dumps(
+                {
+                    "from_provider": reasoning_provider,
+                    "from_model": reasoning_model,
+                    "to_provider": selected_provider,
+                    "to_model": selected_model,
+                    "attempts": failover_attempts,
+                },
+                separators=(",", ":"),
+            ),
         )
 
     actions = plan.get("actions", [])
@@ -1755,46 +2021,66 @@ def main() -> int:
     if reasoning_provider == "openrouter":
         openrouter_runtime = _resolve_openrouter_runtime(config)
     log.info("Reasoning provider selected: %s (model: %s)", reasoning_provider, reasoning_model)
+    failover_policy = _resolve_reasoning_failover_policy(config, reasoning_provider)
+    log.info(
+        "Failover configured: enabled=%s hard_errors=%s order=%s",
+        bool(failover_policy.get("enabled", False)),
+        ",".join(failover_policy.get("hard_error_classes", [])) or "(none)",
+        ",".join(failover_policy.get("order", [])) or "(none)",
+    )
 
     # Validate provider runtime requirements (except in dry-run).
     if not args.dry_run:
+        preflight_issue = ""
         if reasoning_provider == "anthropic":
             if not _HAS_ANTHROPIC:
-                log.error(
-                    "Reasoning provider is 'anthropic' but the 'anthropic' package is missing.\n"
-                    "Install it:\n"
-                    "  pip install anthropic\n"
-                    "Or: pip install -r requirements.txt"
-                )
-                return 1
-            if not os.environ.get("ANTHROPIC_API_KEY", "").strip():
-                log.error(
-                    "Reasoning provider is 'anthropic' but ANTHROPIC_API_KEY is not set.\n"
-                    "  export ANTHROPIC_API_KEY='your-key-here'"
-                )
-                return 1
+                preflight_issue = "anthropic-package"
+            elif not os.environ.get("ANTHROPIC_API_KEY", "").strip():
+                preflight_issue = "anthropic-key"
         elif reasoning_provider == "openrouter":
-            assert openrouter_runtime is not None
-            if not openrouter_runtime.get("api_key"):
-                log.error(
-                    "Reasoning provider is 'openrouter' but OPENROUTER_API_KEY is not set.\n"
-                    "  export OPENROUTER_API_KEY='your-key-here'"
-                )
-                return 1
+            if not openrouter_runtime or not openrouter_runtime.get("api_key"):
+                preflight_issue = "openrouter-key"
         elif reasoning_provider == "openai":
-            assert openai_runtime is not None
-            if not openai_runtime.get("api_key"):
-                log.error(
-                    "Reasoning provider is 'openai' but OPENAI_API_KEY is not set.\n"
-                    "  export OPENAI_API_KEY='your-key-here'"
-                )
-                return 1
+            if not openai_runtime or not openai_runtime.get("api_key"):
+                preflight_issue = "openai-key"
         else:
-            log.error(
-                "Unsupported reasoning provider '%s'. Supported: anthropic, openai, openrouter",
-                reasoning_provider,
-            )
-            return 1
+            preflight_issue = "unsupported-provider"
+
+        if preflight_issue:
+            if bool(failover_policy.get("enabled", False)):
+                log.warning(
+                    "Primary reasoning provider preflight failed (%s); continuing because failover is enabled.",
+                    preflight_issue,
+                )
+            else:
+                if preflight_issue == "anthropic-package":
+                    log.error(
+                        "Reasoning provider is 'anthropic' but the 'anthropic' package is missing.\n"
+                        "Install it:\n"
+                        "  pip install anthropic\n"
+                        "Or: pip install -r requirements.txt"
+                    )
+                elif preflight_issue == "anthropic-key":
+                    log.error(
+                        "Reasoning provider is 'anthropic' but ANTHROPIC_API_KEY is not set.\n"
+                        "  export ANTHROPIC_API_KEY='your-key-here'"
+                    )
+                elif preflight_issue == "openrouter-key":
+                    log.error(
+                        "Reasoning provider is 'openrouter' but OPENROUTER_API_KEY is not set.\n"
+                        "  export OPENROUTER_API_KEY='your-key-here'"
+                    )
+                elif preflight_issue == "openai-key":
+                    log.error(
+                        "Reasoning provider is 'openai' but OPENAI_API_KEY is not set.\n"
+                        "  export OPENAI_API_KEY='your-key-here'"
+                    )
+                else:
+                    log.error(
+                        "Unsupported reasoning provider '%s'. Supported: anthropic, openai, openrouter",
+                        reasoning_provider,
+                    )
+                return 1
 
     log.info("Loaded config: %s v%s", config.get("agent", {}).get("name", "?"), config.get("agent", {}).get("version", "?"))
 

--- a/tools/gaia-assistant.py
+++ b/tools/gaia-assistant.py
@@ -51,6 +51,8 @@ DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-5-20250929"
 DEFAULT_OPENAI_MODEL = "gpt-4.1-mini"
 DEFAULT_CODEX_RUNTIME_MODEL = "gpt-5.3-codex"
 DEFAULT_OPENROUTER_MODEL = "openrouter/auto"
+DEFAULT_REASONING_FAILOVER_ORDER = ("openai", "openrouter", "anthropic")
+DEFAULT_REASONING_FAILOVER_HARD_ERRORS = ("quota", "auth")
 PROVIDER_MODEL_CATALOG_LIMIT = 8
 PROVIDER_DISPLAY_NAMES: Dict[str, str] = {
     "openrouter": "OpenRouter",
@@ -314,6 +316,16 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "provider": "anthropic",
         "model": DEFAULT_ANTHROPIC_MODEL,
         "explicit_provider_override": False,
+        "failover": {
+            "enabled": True,
+            "hard_error_classes": list(DEFAULT_REASONING_FAILOVER_HARD_ERRORS),
+            "order": list(DEFAULT_REASONING_FAILOVER_ORDER),
+            "models": {
+                "anthropic": DEFAULT_ANTHROPIC_MODEL,
+                "openai": DEFAULT_OPENAI_MODEL,
+                "openrouter": DEFAULT_OPENROUTER_MODEL,
+            },
+        },
     },
     "secrets": {
         "store_path": str(DEFAULT_SECRET_STORE),
@@ -463,6 +475,55 @@ def _normalize_config(payload: Dict[str, Any]) -> Dict[str, Any]:
         reasoning.get("explicit_provider_override", False),
         False,
     )
+    failover_cfg = reasoning.setdefault("failover", {})
+    if not isinstance(failover_cfg, dict):
+        failover_cfg = {}
+        reasoning["failover"] = failover_cfg
+    failover_cfg["enabled"] = _normalize_bool_default(failover_cfg.get("enabled", True), True)
+    hard_classes_raw = failover_cfg.get("hard_error_classes", list(DEFAULT_REASONING_FAILOVER_HARD_ERRORS))
+    if isinstance(hard_classes_raw, str):
+        hard_classes_tokens = [token.strip().lower() for token in hard_classes_raw.split(",")]
+    elif isinstance(hard_classes_raw, list):
+        hard_classes_tokens = [str(token).strip().lower() for token in hard_classes_raw]
+    else:
+        hard_classes_tokens = list(DEFAULT_REASONING_FAILOVER_HARD_ERRORS)
+    hard_classes: List[str] = []
+    for token in hard_classes_tokens:
+        if token in DEFAULT_REASONING_FAILOVER_HARD_ERRORS and token not in hard_classes:
+            hard_classes.append(token)
+    if not hard_classes:
+        hard_classes = list(DEFAULT_REASONING_FAILOVER_HARD_ERRORS)
+    failover_cfg["hard_error_classes"] = hard_classes
+
+    order_raw = failover_cfg.get("order", list(DEFAULT_REASONING_FAILOVER_ORDER))
+    if isinstance(order_raw, str):
+        order_tokens = [token.strip().lower() for token in order_raw.split(",")]
+    elif isinstance(order_raw, list):
+        order_tokens = [str(token).strip().lower() for token in order_raw]
+    else:
+        order_tokens = list(DEFAULT_REASONING_FAILOVER_ORDER)
+    normalized_order: List[str] = []
+    for provider in order_tokens:
+        if provider in RUNTIME_REASONING_PROVIDER_CHOICES and provider not in normalized_order:
+            normalized_order.append(provider)
+    if not normalized_order:
+        normalized_order = list(DEFAULT_REASONING_FAILOVER_ORDER)
+    failover_cfg["order"] = normalized_order
+
+    models_raw = failover_cfg.get("models", {})
+    if not isinstance(models_raw, dict):
+        models_raw = {}
+    normalized_models: Dict[str, str] = {}
+    default_models = {
+        "anthropic": DEFAULT_ANTHROPIC_MODEL,
+        "openai": DEFAULT_OPENAI_MODEL,
+        "openrouter": DEFAULT_OPENROUTER_MODEL,
+    }
+    for provider in RUNTIME_REASONING_PROVIDER_CHOICES:
+        value = str(models_raw.get(provider, default_models.get(provider, ""))).strip()
+        if value:
+            normalized_models[provider] = value
+    failover_cfg["models"] = normalized_models
 
     secrets = cfg.setdefault("secrets", {})
     secrets.setdefault("store_path", str(DEFAULT_SECRET_STORE))
@@ -12628,6 +12689,45 @@ def cmd_run(args: argparse.Namespace) -> int:
         reasoning_cfg.get("explicit_provider_override", False),
         False,
     )
+    failover_cfg = reasoning_cfg.get("failover", {})
+    failover_cfg = failover_cfg if isinstance(failover_cfg, dict) else {}
+    failover_enabled = _normalize_bool_default(failover_cfg.get("enabled", True), True)
+    hard_errors_raw = failover_cfg.get("hard_error_classes", list(DEFAULT_REASONING_FAILOVER_HARD_ERRORS))
+    if isinstance(hard_errors_raw, str):
+        hard_errors_tokens = [token.strip().lower() for token in hard_errors_raw.split(",")]
+    elif isinstance(hard_errors_raw, list):
+        hard_errors_tokens = [str(token).strip().lower() for token in hard_errors_raw]
+    else:
+        hard_errors_tokens = list(DEFAULT_REASONING_FAILOVER_HARD_ERRORS)
+    failover_hard_errors: List[str] = []
+    for token in hard_errors_tokens:
+        if token in DEFAULT_REASONING_FAILOVER_HARD_ERRORS and token not in failover_hard_errors:
+            failover_hard_errors.append(token)
+    if not failover_hard_errors:
+        failover_hard_errors = list(DEFAULT_REASONING_FAILOVER_HARD_ERRORS)
+
+    order_raw = failover_cfg.get("order", list(DEFAULT_REASONING_FAILOVER_ORDER))
+    if isinstance(order_raw, str):
+        order_tokens = [token.strip().lower() for token in order_raw.split(",")]
+    elif isinstance(order_raw, list):
+        order_tokens = [str(token).strip().lower() for token in order_raw]
+    else:
+        order_tokens = list(DEFAULT_REASONING_FAILOVER_ORDER)
+    failover_order: List[str] = []
+    for provider_name in order_tokens:
+        if provider_name in RUNTIME_REASONING_PROVIDER_CHOICES and provider_name not in failover_order:
+            failover_order.append(provider_name)
+    if not failover_order:
+        failover_order = list(DEFAULT_REASONING_FAILOVER_ORDER)
+
+    models_raw = failover_cfg.get("models", {})
+    models_raw = models_raw if isinstance(models_raw, dict) else {}
+    failover_models: Dict[str, str] = {}
+    for provider_name in RUNTIME_REASONING_PROVIDER_CHOICES:
+        model_value = str(models_raw.get(provider_name, "")).strip()
+        if model_value:
+            failover_models[provider_name] = model_value
+
     profile_cfg = cfg.get("profile", {})
     profile_cfg = profile_cfg if isinstance(profile_cfg, dict) else {}
     profile_provider = str(profile_cfg.get("default_provider", "")).strip().lower()
@@ -12681,6 +12781,13 @@ def cmd_run(args: argparse.Namespace) -> int:
 
     if not args.dry_run:
         issue = _provider_runtime_dependency_issue(effective_provider, env)
+        if issue and failover_enabled:
+            print(
+                f"[warn] primary runtime provider preflight issue detected ({issue}); "
+                "continuing because failover is enabled.",
+                file=sys.stderr,
+            )
+            issue = None
         if issue == "anthropic-package":
             print(
                 "Reasoning provider is 'anthropic' but the 'anthropic' package is missing.",
@@ -12759,6 +12866,14 @@ def cmd_run(args: argparse.Namespace) -> int:
         env["GAIA_REASONING_PROVIDER"] = effective_provider
     if effective_model:
         env["GAIA_REASONING_MODEL"] = effective_model
+    env["GAIA_REASONING_FAILOVER_ENABLED"] = "1" if failover_enabled else "0"
+    env["GAIA_REASONING_FAILOVER_HARD_ERRORS"] = ",".join(failover_hard_errors)
+    env["GAIA_REASONING_FAILOVER_ORDER"] = ",".join(failover_order)
+    if failover_models:
+        env["GAIA_REASONING_FAILOVER_MODELS"] = ",".join(
+            f"{provider}={model}"
+            for provider, model in sorted(failover_models.items())
+        )
     env["GAIA_AGENT_MEMORY_DIR"] = str(state_dir)
     env["GAIA_ASSISTANT_VERBOSITY"] = str(profile_cfg.get("verbosity", "balanced")).strip() or "balanced"
     profile_tz = str(profile_cfg.get("timezone", "UTC")).strip()
@@ -12780,6 +12895,11 @@ def cmd_run(args: argparse.Namespace) -> int:
         print(f"Reasoning model override: {args.reasoning_model}")
     elif effective_model:
         print(f"Reasoning model: {effective_model} (from launcher config)")
+    print(
+        "Reasoning failover: "
+        f"{'enabled' if failover_enabled else 'disabled'} "
+        f"(classes={','.join(failover_hard_errors)}, order={','.join(failover_order)})"
+    )
     profile_name = str(profile_cfg.get("name", "")).strip()
     if profile_name:
         print(f"Profile name: {profile_name}")

--- a/tools/runtime-failover-check.sh
+++ b/tools/runtime-failover-check.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${GAIA_ASSISTANT_HOME:-}" ]]; then
+  echo "GAIA_ASSISTANT_HOME must be set" >&2
+  exit 1
+fi
+
+pick_port() {
+  python3 - <<'PY'
+import socket
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.bind(("127.0.0.1", 0))
+print(sock.getsockname()[1])
+sock.close()
+PY
+}
+
+OPENAI_PORT="$(pick_port)"
+OPENROUTER_PORT="$(pick_port)"
+TMP_DIR="$(mktemp -d)"
+
+OPENAI_PID=""
+OPENROUTER_PID=""
+cleanup() {
+  if [[ -n "$OPENAI_PID" ]]; then
+    kill "$OPENAI_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$OPENROUTER_PID" ]]; then
+    kill "$OPENROUTER_PID" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat > "$TMP_DIR/mock-openai.py" <<'PY'
+#!/usr/bin/env python3
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        return
+
+    def do_POST(self):
+        if self.path.endswith("/chat/completions"):
+            payload = {
+                "error": {
+                    "message": "You exceeded your current quota",
+                    "type": "insufficient_quota",
+                    "code": "insufficient_quota",
+                }
+            }
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(429)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+
+server = HTTPServer(("127.0.0.1", int(sys.argv[1])), Handler)
+server.serve_forever()
+PY
+
+cat > "$TMP_DIR/mock-openrouter.py" <<'PY'
+#!/usr/bin/env python3
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        return
+
+    def do_POST(self):
+        if self.path.endswith("/chat/completions"):
+            plan = {"reasoning": "fallback-openrouter", "actions": []}
+            payload = {
+                "choices": [
+                    {
+                        "message": {
+                            "content": json.dumps(plan),
+                        }
+                    }
+                ]
+            }
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+
+server = HTTPServer(("127.0.0.1", int(sys.argv[1])), Handler)
+server.serve_forever()
+PY
+
+python3 "$TMP_DIR/mock-openai.py" "$OPENAI_PORT" &
+OPENAI_PID=$!
+python3 "$TMP_DIR/mock-openrouter.py" "$OPENROUTER_PORT" &
+OPENROUTER_PID=$!
+sleep 1
+
+node ./bin/gaia.js init --force >/dev/null
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+cfg_path = Path(os.environ["GAIA_ASSISTANT_HOME"]) / "config.json"
+cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+reasoning = cfg.setdefault("reasoning", {})
+reasoning["provider"] = "openai"
+reasoning["model"] = "gpt-4.1-mini"
+reasoning["explicit_provider_override"] = True
+reasoning["failover"] = {
+    "enabled": True,
+    "hard_error_classes": ["quota", "auth"],
+    "order": ["openrouter", "anthropic"],
+    "models": {
+        "openai": "gpt-4.1-mini",
+        "openrouter": "openrouter/auto",
+        "anthropic": "claude-sonnet-4-5-20250929",
+    },
+}
+cfg_path.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+PY
+
+run_out="$(
+  OPENAI_API_KEY="test-openai-key" \
+  OPENAI_BASE_URL="http://127.0.0.1:${OPENAI_PORT}/v1" \
+  OPENROUTER_API_KEY="test-openrouter-key" \
+  OPENROUTER_BASE_URL="http://127.0.0.1:${OPENROUTER_PORT}/api/v1" \
+  node ./bin/gaia.js run --mode single 2>&1
+)"
+
+[[ "$run_out" == *"Reasoning provider: openai (from launcher config)"* ]]
+[[ "$run_out" == *"Reasoning failover: enabled"* ]]
+[[ "$run_out" == *"Reasoning failover triggered:"* ]]
+[[ "$run_out" == *"Reasoning failover succeeded: openai/gpt-4.1-mini -> openrouter/openrouter/auto"* ]]
+[[ "$run_out" == *"No actions proposed this cycle."* ]]


### PR DESCRIPTION
## Summary
- Add deterministic runtime failover for reasoning hard-error classes (`quota`, `auth`) in `gaia run` / `agent-loop`.
- Continue past primary-provider preflight failures when failover is enabled and emit explicit failover policy logs.
- Add provider/model failover policy defaults + config/env normalization (`reasoning.failover`).
- Add deterministic UAT coverage via `tools/runtime-failover-check.sh` and map it to `run` command governance.
- Document failover behavior and add UAT-governance change record.

## Track Declaration
- [x] `assistant-track`
- [ ] `framework-track`
- [ ] Cross-track (`assistant-track` + `framework-track`)

## Risk Level
- [ ] Low
- [ ] Medium
- [x] High (requires explicit maintainer review before merge)

## Self-Evolution Applicability
- [ ] Applies: this PR changes self-evolution behavior/governance.
- [x] Not applicable: no self-evolution behavior/governance changes.

## Self-Evolution Evidence (required when applicability is "Applies")
- Baseline evidence: N/A
- Delta observed: N/A
- Thresholds and guardrails: N/A
- Rollback/fallback: N/A
- Risk notes: N/A

## Validation
- [x] `make check-all`
- [x] `make test-smoke` (if assistant/runtime behavior changed)
- [x] `make test-uat` (required for assistant feature changes)
- [x] Additional targeted checks documented below

Additional targeted checks:
- `python3 -m py_compile tools/gaia-assistant.py tools/gaia_assistant_parser.py tools/gaia_assistant_onboarding.py tools/agent-loop.py`
- `GAIA_ASSISTANT_HOME="$(mktemp -d)" bash ./tools/runtime-failover-check.sh`
- `python3 tools/check-uat-policy.py --base-ref origin/main --reviewer TonyThePredictor`

## Checklist
- [x] Changes are small, safe, and incremental
- [x] No breaking changes to structure or website
- [x] Docs follow repo markdown standards
- [x] Links added/updated were verified
- [x] Track and risk are declared
- [x] Self-evolution applicability declared and rubric completed when required
- [x] Handoff notes included (files changed, validations, follow-ups)
- [x] New feature surfaces include UAT updates in this PR

## UAT Change Justification
This PR changes protected UAT governance files to keep `run` command coverage aligned with new runtime failover behavior.

- Why needed: issue #146 adds deterministic failover on hard runtime errors (quota/auth). Without governance updates, regressions in fallback trigger/order/success visibility would not be caught.
- What changed: `assistant/feature-catalog.json` now maps `run` to `run_failover_quota_hard_error`; `assistant/uat-scenarios.json` adds that scenario; `tools/runtime-failover-check.sh` provides deterministic local mocks to force OpenAI `insufficient_quota` and validate OpenRouter fallback success logs.
- Risk: high, because runtime provider-selection behavior changes during live runs.
- Confidence: scenario is local/offline deterministic, asserts policy visibility + trigger + success transition, and complements existing `run_single_dry` coverage.
- Governance record: `docs/uat-changes/2026-02-15-runtime-failover-hard-error-coverage.md`.

## Notes
- Closes #146.
- Mandatory gate evidence (work type: high-risk implementation):
  - `gaia-security-reviewer`: reviewed failover trigger boundary (only configured hard classes), provider allowlist normalization, and preflight bypass conditions; no unresolved findings.
  - `gaia-qa-evaluator`: go decision based on passing smoke (`27/27`), UAT (`48/48`), deterministic failover check, and `check-all`.
- State sync docs (`STATUS.md`, `ROADMAP.md`, `CHANGELOG.md`) not changed in this PR: no lane/roadmap/changelog contract changed; issue-specific implementation and UAT evidence are contained in code/docs above.
