### PR TITLE
feat(runtime): add provider-aware reasoning effort selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
-- _Nothing yet._
+- Provider-aware reasoning effort selector across onboarding/config/runtime (`reasoning.effort`, `gaia onboard --effort`, `gaia run --reasoning-effort`) with deterministic runtime payload mapping for supported provider/model combinations (`#147`)
+- Deterministic runtime effort regression check harness and UAT scenario/governance coverage (`tools/runtime-effort-check.sh`, `assistant/uat-scenarios.json`, `assistant/feature-catalog.json`, `docs/uat-changes/2026-02-15-reasoning-effort-selector-coverage.md`, `#147`)
 
 ### Changed
-- _Nothing yet._
+- `gaia run` startup output now reports effective reasoning effort and agent-loop logs explicit effort no-op behavior for unsupported provider/model paths (`#147`)
 
 ### Removed
 - _Nothing yet._

--- a/STATUS.md
+++ b/STATUS.md
@@ -29,6 +29,7 @@ current active sprint window.
 - `Sprint governance/state sync reset for docs and status surfaces` (`#129`)
 - `Sprint live preview rebuild from executable Gaia traces` (`#132`)
 - npm release `@gaia-minds/assistant-cli@0.4.0` (`#133`, tag `v0.4.0`)
+- `[Sprint][Assistant] Add model effort selector across onboarding/config/runtime` (`#147`)
 
 ## In Progress
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -820,11 +820,21 @@ and can be overridden per run:
 # one-off override from Gaia launcher
 gaia run --mode single --reasoning-provider openai --reasoning-model gpt-4.1-mini
 gaia run --mode single --reasoning-provider openrouter --reasoning-model openrouter/auto
+gaia run --mode single --reasoning-provider openai --reasoning-model gpt-5.3-codex --reasoning-effort high
 
 # npm/local clone equivalent
 npm run gaia -- run --mode single --reasoning-provider openai --reasoning-model gpt-4.1-mini
 npm run gaia -- run --mode single --reasoning-provider openrouter --reasoning-model openrouter/auto
+npm run gaia -- run --mode single --reasoning-provider openai --reasoning-model gpt-5.3-codex --reasoning-effort high
 ```
+
+Reasoning effort selector:
+
+- Config contract: `reasoning.effort` (`minimal`, `low`, `medium`, `high`).
+- Onboarding supports `--effort` and run supports `--reasoning-effort`.
+- `gaia config set effort <value>` persists effort (`gaia config get effort`).
+- Runtime applies effort only when the current provider/model supports it and
+  logs explicit no-op behavior when unsupported.
 
 Runtime hard-error failover:
 

--- a/assistant/feature-catalog.json
+++ b/assistant/feature-catalog.json
@@ -72,7 +72,7 @@
     {"path": "auth login", "scenarios": ["auth_login_unsupported_provider", "auth_login_claude_cli_source"]},
     {"path": "auth link", "scenarios": ["auth_link_rejects_openclaw_source", "auth_link_codex_missing_credentials"]},
     {"path": "auth status", "scenarios": ["auth_status_command", "auth_login_claude_cli_source"]},
-    {"path": "run", "scenarios": ["run_single_dry", "run_failover_quota_hard_error"]}
+    {"path": "run", "scenarios": ["run_single_dry", "run_failover_quota_hard_error", "run_reasoning_effort_selector"]}
   ],
   "agent_actions": [
     {"type": "verify_resources", "scenarios": ["agent_loop_dry_run"]},

--- a/assistant/uat-scenarios.json
+++ b/assistant/uat-scenarios.json
@@ -17,9 +17,9 @@
     },
     {
       "id": "onboard_openai_nostore",
-      "description": "OpenAI onboarding succeeds in deterministic mode",
+      "description": "OpenAI onboarding persists model and effort selection in deterministic mode",
       "expect_exit": 0,
-      "command": "node ./bin/gaia.js onboard --provider openai --api-key test-key --model gpt-4.1-mini --yes --no-store-api-key >/dev/null"
+      "command": "node ./bin/gaia.js onboard --provider openai --api-key test-key --model gpt-4.1-mini --effort high --yes --no-store-api-key >/dev/null && effort=$(node ./bin/gaia.js config get effort) && [[ \"$effort\" == \"high\" ]]"
     },
     {
       "id": "onboard_claude_code_oauth",
@@ -284,6 +284,12 @@
       "description": "Gaia run applies deterministic provider failover on quota hard errors with visible logs",
       "expect_exit": 0,
       "command": "bash ./tools/runtime-failover-check.sh"
+    },
+    {
+      "id": "run_reasoning_effort_selector",
+      "description": "Gaia run applies normalized reasoning effort only when provider/model supports it",
+      "expect_exit": 0,
+      "command": "bash ./tools/runtime-effort-check.sh"
     },
     {
       "id": "agent_loop_dry_run",

--- a/docs/uat-changes/2026-02-15-reasoning-effort-selector-coverage.md
+++ b/docs/uat-changes/2026-02-15-reasoning-effort-selector-coverage.md
@@ -1,0 +1,43 @@
+# Reasoning Effort Selector UAT Coverage Update (2026-02-15)
+
+## Why this change
+
+Issue `#147` adds a provider-aware model effort selector across onboarding,
+config, and runtime paths. This lane updates protected UAT governance files so
+the `run` command path and onboarding contract stay covered by deterministic
+scenarios.
+
+Updated mapping:
+
+- `run` now includes `run_reasoning_effort_selector`.
+
+Updated scenarios:
+
+- `onboard_openai_nostore` now verifies onboarding `--effort` persistence.
+- `run_reasoning_effort_selector` validates:
+  - effort propagation for supported provider/model combinations
+  - deterministic no-op logging for unsupported provider/model combinations
+
+## Risk
+
+- High.
+- Effort wiring changes runtime request payload behavior and startup contract
+  output; missing UAT coverage could allow silent regressions.
+
+## Confidence and Safeguards
+
+- Scenario `run_reasoning_effort_selector` uses local deterministic mock
+  endpoints only (`tools/runtime-effort-check.sh`), with explicit payload
+  assertions.
+- The unsupported-model lane fails if effort is sent when it should be omitted.
+- Existing baseline run coverage (`run_single_dry`,
+  `run_failover_quota_hard_error`) remains unchanged.
+
+## Validation
+
+- `python3 -m py_compile tools/gaia-assistant.py tools/gaia_assistant_parser.py tools/gaia_assistant_onboarding.py tools/agent-loop.py`
+- `bash ./tools/runtime-effort-check.sh`
+- `make test-smoke`
+- `make test-uat`
+- `make check-all`
+- `python3 tools/check-uat-policy.py --base-ref origin/main --reviewer TonyThePredictor`

--- a/tools/agent-config.yml
+++ b/tools/agent-config.yml
@@ -22,6 +22,7 @@ agent:
 # ---------------------------------------------------------------------------
 reasoning:
   provider: "anthropic"  # anthropic | openai | openrouter
+  effort: ""  # optional: minimal | low | medium | high (empty = provider default)
   models:
     anthropic: "claude-sonnet-4-5-20250929"
     openai: "gpt-4.1-mini"

--- a/tools/agent-loop.py
+++ b/tools/agent-loop.py
@@ -132,6 +132,8 @@ DEFAULT_OPENROUTER_MODEL = "openrouter/auto"
 SUPPORTED_REASONING_PROVIDERS = {"anthropic", "openai", "openrouter"}
 DEFAULT_REASONING_FAILOVER_ORDER = ("openai", "openrouter", "anthropic")
 DEFAULT_REASONING_FAILOVER_ERROR_CLASSES = ("quota", "auth")
+REASONING_EFFORT_CHOICES = ("minimal", "low", "medium", "high")
+ANTHROPIC_EFFORT_CHOICES = {"low", "medium", "high"}
 
 
 # ---------------------------------------------------------------------------
@@ -337,6 +339,83 @@ def _resolve_openrouter_runtime(config: Dict[str, Any]) -> Dict[str, Any]:
         "app_url": app_url,
         "timeout_seconds": timeout_seconds,
     }
+
+
+def _normalize_reasoning_effort(value: Any, *, default_value: str = "") -> str:
+    token = str(value).strip().lower()
+    if not token:
+        return default_value
+    if token in REASONING_EFFORT_CHOICES:
+        return token
+    if token in {"auto", "default", "none", "off", "disabled"}:
+        return ""
+    return default_value
+
+
+def _resolve_reasoning_effort(config: Dict[str, Any]) -> str:
+    override = os.environ.get("GAIA_REASONING_EFFORT", "").strip()
+    if override:
+        normalized_override = _normalize_reasoning_effort(override, default_value="__invalid__")
+        if normalized_override == "__invalid__":
+            log.warning(
+                "Unsupported GAIA_REASONING_EFFORT=%s; ignoring effort override",
+                override,
+            )
+            return ""
+        return normalized_override
+
+    reasoning = config.get("reasoning", {})
+    reasoning = reasoning if isinstance(reasoning, dict) else {}
+    return _normalize_reasoning_effort(reasoning.get("effort", ""), default_value="")
+
+
+def _openai_model_supports_effort(model: str) -> bool:
+    normalized = str(model).strip().lower()
+    return normalized.startswith(("gpt-5", "o1", "o3", "o4"))
+
+
+def _openrouter_model_supports_effort(model: str) -> bool:
+    normalized = str(model).strip().lower()
+    if not normalized or normalized == "openrouter/auto":
+        return False
+    markers = ("gpt-5", "o1", "o3", "o4", "grok", "claude-opus-4-6")
+    return any(marker in normalized for marker in markers)
+
+
+def _anthropic_model_supports_effort(model: str) -> bool:
+    normalized = str(model).strip().lower()
+    return "claude-opus-4-6" in normalized
+
+
+def _resolve_reasoning_effort_payload(
+    provider: str,
+    model: str,
+    effort: str,
+) -> Tuple[Dict[str, Any], str]:
+    if not effort:
+        return {}, ""
+    if provider == "openai":
+        if _openai_model_supports_effort(model):
+            return {"reasoning_effort": effort}, effort
+        return {}, ""
+    if provider == "openrouter":
+        if _openrouter_model_supports_effort(model):
+            return {"reasoning": {"effort": effort}}, effort
+        return {}, ""
+    if provider == "anthropic":
+        if not _anthropic_model_supports_effort(model):
+            return {}, ""
+        anthropic_effort = "low" if effort == "minimal" else effort
+        if anthropic_effort not in ANTHROPIC_EFFORT_CHOICES:
+            return {}, ""
+        return (
+            {
+                "thinking": {"type": "enabled"},
+                "output_config": {"thinking": {"type": "adaptive", "effort": anthropic_effort}},
+            },
+            anthropic_effort,
+        )
+    return {}, ""
 
 
 def _parse_bool_default(value: Any, default_value: bool) -> bool:
@@ -1298,6 +1377,7 @@ def _openai_chat_completion(
     user_prompt: str,
     max_tokens: int,
     temperature: float,
+    reasoning_effort: str = "",
 ) -> str:
     """Call OpenAI chat completions API and return text response."""
     endpoint = f"{client['base_url']}/chat/completions"
@@ -1310,6 +1390,8 @@ def _openai_chat_completion(
         "max_tokens": max_tokens,
         "temperature": temperature,
     }
+    if reasoning_effort:
+        payload["reasoning_effort"] = reasoning_effort
     headers = {
         "Authorization": f"Bearer {client['api_key']}",
         "Content-Type": "application/json",
@@ -1345,6 +1427,7 @@ def _openrouter_chat_completion(
     user_prompt: str,
     max_tokens: int,
     temperature: float,
+    reasoning: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Call OpenRouter chat completions API and return text response."""
     endpoint = f"{client['base_url']}/chat/completions"
@@ -1357,6 +1440,8 @@ def _openrouter_chat_completion(
         "max_tokens": max_tokens,
         "temperature": temperature,
     }
+    if reasoning:
+        payload["reasoning"] = reasoning
     headers = {
         "Authorization": f"Bearer {client['api_key']}",
         "Content-Type": "application/json",
@@ -1413,6 +1498,24 @@ def ask_model_for_plan(
     except (TypeError, ValueError):
         temperature_float = 0.3
 
+    requested_effort = _resolve_reasoning_effort(config)
+    effort_payload, applied_effort = _resolve_reasoning_effort_payload(provider, model, requested_effort)
+    if requested_effort:
+        if applied_effort:
+            log.info(
+                "Applied reasoning effort: provider=%s model=%s effort=%s",
+                provider,
+                model,
+                applied_effort,
+            )
+        else:
+            log.info(
+                "Reasoning effort not applied: provider=%s model=%s effort=%s (unsupported provider/model)",
+                provider,
+                model,
+                requested_effort,
+            )
+
     system_prompt = SYSTEM_PROMPT_TEMPLATE.format(constitution=constitution)
 
     n_decisions = 10
@@ -1437,13 +1540,15 @@ def ask_model_for_plan(
     text: str
     try:
         if provider == "anthropic":
-            response = client.messages.create(
-                model=model,
-                max_tokens=max_tokens_int,
-                temperature=temperature_float,
-                system=system_prompt,
-                messages=[{"role": "user", "content": user_prompt}],
-            )
+            anthropic_payload: Dict[str, Any] = {
+                "model": model,
+                "max_tokens": max_tokens_int,
+                "temperature": temperature_float,
+                "system": system_prompt,
+                "messages": [{"role": "user", "content": user_prompt}],
+            }
+            anthropic_payload.update(effort_payload)
+            response = client.messages.create(**anthropic_payload)
             text = _extract_anthropic_text(response)
         elif provider == "openai":
             if not isinstance(client, dict):
@@ -1455,6 +1560,7 @@ def ask_model_for_plan(
                 user_prompt=user_prompt,
                 max_tokens=max_tokens_int,
                 temperature=temperature_float,
+                reasoning_effort=str(effort_payload.get("reasoning_effort", "")),
             )
         elif provider == "openrouter":
             if not isinstance(client, dict):
@@ -1466,6 +1572,7 @@ def ask_model_for_plan(
                 user_prompt=user_prompt,
                 max_tokens=max_tokens_int,
                 temperature=temperature_float,
+                reasoning=effort_payload.get("reasoning") if isinstance(effort_payload.get("reasoning"), dict) else None,
             )
         else:
             raise RuntimeError(f"Unsupported reasoning provider: {provider}")

--- a/tools/gaia-assistant.py
+++ b/tools/gaia-assistant.py
@@ -53,6 +53,8 @@ DEFAULT_CODEX_RUNTIME_MODEL = "gpt-5.3-codex"
 DEFAULT_OPENROUTER_MODEL = "openrouter/auto"
 DEFAULT_REASONING_FAILOVER_ORDER = ("openai", "openrouter", "anthropic")
 DEFAULT_REASONING_FAILOVER_HARD_ERRORS = ("quota", "auth")
+REASONING_EFFORT_CHOICES = ("minimal", "low", "medium", "high")
+REASONING_EFFORT_WITH_AUTO_CHOICES = ("auto", *REASONING_EFFORT_CHOICES)
 PROVIDER_MODEL_CATALOG_LIMIT = 8
 PROVIDER_DISPLAY_NAMES: Dict[str, str] = {
     "openrouter": "OpenRouter",
@@ -177,6 +179,9 @@ PROFILE_KEY_MAP = {
     "verbosity": ("profile", "verbosity"),
     "provider": ("profile", "default_provider"),
     "default_provider": ("profile", "default_provider"),
+    "effort": ("reasoning", "effort"),
+    "reasoning_effort": ("reasoning", "effort"),
+    "reasoning-effort": ("reasoning", "effort"),
     "response_profile": ("profile", "response_profile"),
     "response-style": ("profile", "response_profile"),
     "style": ("profile", "response_profile"),
@@ -315,6 +320,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "reasoning": {
         "provider": "anthropic",
         "model": DEFAULT_ANTHROPIC_MODEL,
+        "effort": "",
         "explicit_provider_override": False,
         "failover": {
             "enabled": True,
@@ -447,6 +453,22 @@ def _normalize_bool_default(value: Any, default_value: bool) -> bool:
     return default_value
 
 
+def _normalize_reasoning_effort(value: Any, *, default_value: str = "") -> str:
+    token = str(value).strip().lower()
+    if not token:
+        return default_value
+    if token in REASONING_EFFORT_CHOICES:
+        return token
+    if token in ("auto", "default", "none", "off", "disabled"):
+        return ""
+    return default_value
+
+
+def _reasoning_effort_display(value: str) -> str:
+    normalized = _normalize_reasoning_effort(value, default_value="")
+    return normalized or "auto"
+
+
 def _normalize_int_default(
     value: Any,
     *,
@@ -471,6 +493,7 @@ def _normalize_config(payload: Dict[str, Any]) -> Dict[str, Any]:
     reasoning = cfg.setdefault("reasoning", {})
     reasoning.setdefault("provider", "anthropic")
     reasoning.setdefault("model", DEFAULT_ANTHROPIC_MODEL)
+    reasoning["effort"] = _normalize_reasoning_effort(reasoning.get("effort", ""), default_value="")
     reasoning["explicit_provider_override"] = _normalize_bool_default(
         reasoning.get("explicit_provider_override", False),
         False,
@@ -757,6 +780,14 @@ def _normalize_config_value(key: str, value: str) -> Tuple[Optional[Any], Option
             return None, (
                 f"Invalid provider '{value}'. "
                 f"Expected one of: {', '.join(PROFILE_PROVIDER_CHOICES)}."
+            )
+        return normalized, None
+    if canonical_key in ("effort", "reasoning_effort", "reasoning-effort"):
+        normalized = _normalize_reasoning_effort(raw, default_value="__invalid__")
+        if normalized == "__invalid__":
+            return None, (
+                f"Invalid reasoning effort '{value}'. "
+                f"Expected one of: {', '.join(REASONING_EFFORT_WITH_AUTO_CHOICES)}."
             )
         return normalized, None
     if canonical_key in ("response_profile", "response-style", "style"):
@@ -4456,6 +4487,7 @@ def _set_reasoning_config(
     provider: str,
     model: Optional[str],
     *,
+    effort: Optional[str] = None,
     explicit_provider_override: bool,
 ) -> None:
     cfg = _ensure_config_exists(cfg_path)
@@ -4469,6 +4501,10 @@ def _set_reasoning_config(
         reasoning["model"] = model.strip()
     else:
         reasoning["model"] = _default_model_for_provider(provider)
+    if effort is not None:
+        reasoning["effort"] = _normalize_reasoning_effort(effort, default_value="")
+    elif "effort" not in reasoning:
+        reasoning["effort"] = ""
     reasoning["explicit_provider_override"] = bool(explicit_provider_override)
     _write_json(cfg_path, cfg)
 
@@ -4797,11 +4833,52 @@ def _select_provider_model(
         print("Model id cannot be empty.")
 
 
+def _select_reasoning_effort(
+    *,
+    cfg_path: Path,
+    explicit_effort: Optional[str],
+    non_interactive: bool,
+) -> str:
+    if explicit_effort is not None:
+        normalized_explicit = _normalize_reasoning_effort(explicit_effort, default_value="__invalid__")
+        if normalized_explicit == "__invalid__":
+            raise ValueError(
+                f"Invalid reasoning effort '{explicit_effort}'. "
+                f"Expected one of: {', '.join(REASONING_EFFORT_WITH_AUTO_CHOICES)}."
+            )
+        return normalized_explicit
+
+    cfg = _ensure_config_exists(cfg_path)
+    reasoning = cfg.get("reasoning", {})
+    reasoning = reasoning if isinstance(reasoning, dict) else {}
+    configured_effort = _normalize_reasoning_effort(reasoning.get("effort", ""), default_value="")
+    if non_interactive:
+        return configured_effort
+
+    options: List[Tuple[str, str]] = [
+        ("", "Auto (provider/model default)"),
+        ("minimal", "Minimal"),
+        ("low", "Low"),
+        ("medium", "Medium"),
+        ("high", "High"),
+    ]
+    default_index = 0
+    if configured_effort in REASONING_EFFORT_CHOICES:
+        default_index = list(REASONING_EFFORT_CHOICES).index(configured_effort) + 1
+    return _prompt_choice(
+        "Select reasoning effort:",
+        options,
+        default_index=default_index,
+        non_interactive=False,
+    )
+
+
 def _configure_api_key_provider(
     cfg_path: Path,
     provider: str,
     api_key_env: str,
     model: Optional[str],
+    effort: Optional[str],
     api_key: Optional[str],
     secret_store_override: Optional[str],
     no_prompt: bool,
@@ -4846,11 +4923,13 @@ def _configure_api_key_provider(
         cfg_path,
         provider,
         model,
+        effort=effort,
         explicit_provider_override=True,
     )
     print("[ok] reasoning provider configured")
     print(f"     provider: {provider}")
     print(f"     model:    {model or _default_model_for_provider(provider)}")
+    print(f"     effort:   {_reasoning_effort_display(effort or '')}")
     return 0
 
 
@@ -5264,6 +5343,16 @@ def cmd_onboard(args: argparse.Namespace) -> int:
         print(f"Supported providers: {', '.join(ONBOARD_PROVIDER_CHOICES)}", file=sys.stderr)
         return 1
     print(f"[ok] selected provider: {provider}")
+    try:
+        selected_effort = _select_reasoning_effort(
+            cfg_path=cfg_path,
+            explicit_effort=getattr(args, "effort", None),
+            non_interactive=args.yes,
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(f"[ok] selected effort: {_reasoning_effort_display(selected_effort)}")
 
     if provider == "openai-codex":
         selected_model = _select_provider_model(
@@ -5294,6 +5383,7 @@ def cmd_onboard(args: argparse.Namespace) -> int:
             no_prompt=True,
             profile_id=None,
             model=selected_model,
+            effort=selected_effort,
         )
         return cmd_auth_login(login_args)
 
@@ -5326,6 +5416,7 @@ def cmd_onboard(args: argparse.Namespace) -> int:
             no_prompt=True,
             profile_id=None,
             model=selected_model,
+            effort=selected_effort,
         )
         return cmd_auth_login(login_args)
 
@@ -5353,6 +5444,7 @@ def cmd_onboard(args: argparse.Namespace) -> int:
         provider=provider,
         api_key_env=api_key_env,
         model=provider_model,
+        effort=selected_effort,
         api_key=args.api_key,
         secret_store_override=args.secret_store,
         no_prompt=args.yes,
@@ -5374,6 +5466,9 @@ def cmd_auth_login(args: argparse.Namespace) -> int:
     provider = str(args.provider).strip().lower()
     source = str(args.source).strip().lower()
     selected_model = str(getattr(args, "model", "")).strip()
+    selected_effort_raw = getattr(args, "effort", None)
+    selected_effort = _normalize_reasoning_effort(selected_effort_raw, default_value="")
+    effort_requested = selected_effort_raw is not None
     runtime_aligned_model = ""
 
     if provider not in AUTH_PROVIDER_CHOICES:
@@ -5449,7 +5544,9 @@ def cmd_auth_login(args: argparse.Namespace) -> int:
         reasoning = reasoning if isinstance(reasoning, dict) else {}
         aligned_provider = str(reasoning.get("provider", "")).strip().lower()
         aligned_model = str(reasoning.get("model", "")).strip()
+        aligned_effort = _normalize_reasoning_effort(reasoning.get("effort", ""), default_value="")
         explicit_override = _normalize_bool_default(reasoning.get("explicit_provider_override", False), False)
+        updated_runtime = False
 
         if runtime_aligned:
             runtime_aligned_model = aligned_model or DEFAULT_CODEX_RUNTIME_MODEL
@@ -5457,10 +5554,17 @@ def cmd_auth_login(args: argparse.Namespace) -> int:
         if selected_model and aligned_provider == "openai" and not explicit_override:
             if aligned_model != selected_model:
                 reasoning["model"] = selected_model
-                cfg["reasoning"] = reasoning
-                _write_json(cfg_path, _normalize_config(cfg))
+                updated_runtime = True
             runtime_aligned = True
             runtime_aligned_model = selected_model
+        if effort_requested and aligned_provider == "openai" and not explicit_override:
+            if aligned_effort != selected_effort:
+                reasoning["effort"] = selected_effort
+                updated_runtime = True
+            runtime_aligned = True
+        if updated_runtime:
+            cfg["reasoning"] = reasoning
+            _write_json(cfg_path, _normalize_config(cfg))
 
     store = _load_gaia_auth_store(gaia_auth_store)
     profiles = store.get("profiles", {}) if isinstance(store, dict) else {}
@@ -5479,6 +5583,8 @@ def cmd_auth_login(args: argparse.Namespace) -> int:
             print(f"[ok] Runtime defaults aligned for OAuth provider: openai/{effective_model}")
         else:
             print(f"[ok] Runtime defaults aligned for OAuth provider: {provider}/{effective_model}")
+        if effort_requested:
+            print(f"[ok] Runtime effort aligned: {_reasoning_effort_display(selected_effort)}")
     print("")
     if source == "codex-cli":
         print("Note: credentials are stored in local Gaia auth store, not in this repository.")
@@ -5910,6 +6016,8 @@ def cmd_config_get(args: argparse.Namespace) -> int:
         )
         print("", end="")
         return 0
+    if key in ("effort", "reasoning_effort", "reasoning-effort"):
+        value = _reasoning_effort_display(str(value))
     if isinstance(value, (dict, list)):
         print(json.dumps(value, indent=2))
     else:
@@ -5995,15 +6103,18 @@ def cmd_config_set(args: argparse.Namespace) -> int:
         reasoning["explicit_provider_override"] = True
 
     _write_json(cfg_path, _normalize_config(cfg))
+    display_value = normalized
+    if key in ("effort", "reasoning_effort", "reasoning-effort"):
+        display_value = _reasoning_effort_display(str(normalized))
     _write_action_trace(
         trace_dir=trace_dir,
         action_type="config_set",
         input_summary=f"key={key}",
-        output_summary=f"set to {normalized}",
+        output_summary=f"set to {display_value}",
         duration_ms=(time.perf_counter() - start) * 1000,
         permission_level=permission_level,
     )
-    print(f"{path[0]}.{path[1]}={normalized}")
+    print(f"{path[0]}.{path[1]}={display_value}")
     return 0
 
 
@@ -12733,8 +12844,21 @@ def cmd_run(args: argparse.Namespace) -> int:
     profile_provider = str(profile_cfg.get("default_provider", "")).strip().lower()
     configured_provider = str(reasoning_cfg.get("provider", "")).strip().lower()
     configured_model = str(reasoning_cfg.get("model", "")).strip()
+    configured_effort = _normalize_reasoning_effort(reasoning_cfg.get("effort", ""), default_value="")
     effective_provider = str(args.reasoning_provider or configured_provider or profile_provider).strip().lower()
     effective_model = str(args.reasoning_model or configured_model).strip()
+    if getattr(args, "reasoning_effort", None) is None:
+        effective_effort = configured_effort
+    else:
+        override_effort = _normalize_reasoning_effort(args.reasoning_effort, default_value="__invalid__")
+        if override_effort == "__invalid__":
+            print(
+                f"Invalid reasoning effort override: {args.reasoning_effort}. "
+                f"Expected one of: {', '.join(REASONING_EFFORT_WITH_AUTO_CHOICES)}.",
+                file=sys.stderr,
+            )
+            return 1
+        effective_effort = override_effort
 
     if not effective_provider:
         effective_provider = "anthropic"
@@ -12866,6 +12990,10 @@ def cmd_run(args: argparse.Namespace) -> int:
         env["GAIA_REASONING_PROVIDER"] = effective_provider
     if effective_model:
         env["GAIA_REASONING_MODEL"] = effective_model
+    if effective_effort:
+        env["GAIA_REASONING_EFFORT"] = effective_effort
+    else:
+        env.pop("GAIA_REASONING_EFFORT", None)
     env["GAIA_REASONING_FAILOVER_ENABLED"] = "1" if failover_enabled else "0"
     env["GAIA_REASONING_FAILOVER_HARD_ERRORS"] = ",".join(failover_hard_errors)
     env["GAIA_REASONING_FAILOVER_ORDER"] = ",".join(failover_order)
@@ -12895,6 +13023,10 @@ def cmd_run(args: argparse.Namespace) -> int:
         print(f"Reasoning model override: {args.reasoning_model}")
     elif effective_model:
         print(f"Reasoning model: {effective_model} (from launcher config)")
+    if getattr(args, "reasoning_effort", None) is not None:
+        print(f"Reasoning effort override: {_reasoning_effort_display(effective_effort)}")
+    else:
+        print(f"Reasoning effort: {_reasoning_effort_display(configured_effort)} (from launcher config)")
     print(
         "Reasoning failover: "
         f"{'enabled' if failover_enabled else 'disabled'} "

--- a/tools/gaia_assistant_parser.py
+++ b/tools/gaia_assistant_parser.py
@@ -30,6 +30,7 @@ def build_parser(ctx: Dict[str, Any]) -> argparse.ArgumentParser:
     POLICY_SOURCE_CHOICES = ctx["POLICY_SOURCE_CHOICES"]
     POLICY_TOOL_CHOICES = ctx["POLICY_TOOL_CHOICES"]
     PROFILE_KEY_MAP = ctx["PROFILE_KEY_MAP"]
+    REASONING_EFFORT_WITH_AUTO_CHOICES = ctx["REASONING_EFFORT_WITH_AUTO_CHOICES"]
     REMINDER_DEFAULT_CADENCE_MINUTES = ctx["REMINDER_DEFAULT_CADENCE_MINUTES"]
     REMINDER_DEFAULT_WINDOW_MINUTES = ctx["REMINDER_DEFAULT_WINDOW_MINUTES"]
     RESPONSE_PROFILE_CHOICES = ctx["RESPONSE_PROFILE_CHOICES"]
@@ -138,6 +139,12 @@ def build_parser(ctx: Dict[str, Any]) -> argparse.ArgumentParser:
         "--model",
         default=None,
         help="Reasoning model to set during onboarding",
+    )
+    onboard.add_argument(
+        "--effort",
+        choices=list(REASONING_EFFORT_WITH_AUTO_CHOICES),
+        default=None,
+        help="Reasoning effort to set during onboarding (auto/minimal/low/medium/high)",
     )
     onboard.add_argument(
         "--secret-store",
@@ -1029,6 +1036,12 @@ def build_parser(ctx: Dict[str, Any]) -> argparse.ArgumentParser:
         "--reasoning-model",
         default=None,
         help="Override reasoning model for this run",
+    )
+    run.add_argument(
+        "--reasoning-effort",
+        choices=list(REASONING_EFFORT_WITH_AUTO_CHOICES),
+        default=None,
+        help="Override reasoning effort for this run (auto/minimal/low/medium/high)",
     )
     run.add_argument("--dry-run", action="store_true", help="Plan only, do not execute actions")
     run.add_argument("--verbose", action="store_true", help="Verbose logs")

--- a/tools/runtime-effort-check.sh
+++ b/tools/runtime-effort-check.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${GAIA_ASSISTANT_HOME:-}" ]]; then
+  echo "GAIA_ASSISTANT_HOME must be set" >&2
+  exit 1
+fi
+
+pick_port() {
+  python3 - <<'PY'
+import socket
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.bind(("127.0.0.1", 0))
+print(sock.getsockname()[1])
+sock.close()
+PY
+}
+
+OPENAI_PORT="$(pick_port)"
+TMP_DIR="$(mktemp -d)"
+OPENAI_PID=""
+
+cleanup() {
+  if [[ -n "$OPENAI_PID" ]]; then
+    kill "$OPENAI_PID" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat > "$TMP_DIR/mock-openai-effort.py" <<'PY'
+#!/usr/bin/env python3
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        return
+
+    def do_POST(self):
+        if not self.path.endswith("/chat/completions"):
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length).decode("utf-8")
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            self.send_response(400)
+            self.end_headers()
+            return
+
+        model = str(payload.get("model", ""))
+        effort = payload.get("reasoning_effort")
+        if model == "gpt-5.3-codex" and effort != "high":
+            response = {
+                "error": {
+                    "message": f"expected reasoning_effort=high for {model}, got {effort!r}",
+                    "type": "invalid_request_error",
+                }
+            }
+            raw = json.dumps(response).encode("utf-8")
+            self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+            return
+
+        if model == "gpt-4.1-mini" and effort is not None:
+            response = {
+                "error": {
+                    "message": f"reasoning_effort must be omitted for {model}",
+                    "type": "invalid_request_error",
+                }
+            }
+            raw = json.dumps(response).encode("utf-8")
+            self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+            return
+
+        plan = {"reasoning": "effort-check-ok", "actions": []}
+        response = {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(plan),
+                    }
+                }
+            ]
+        }
+        raw = json.dumps(response).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+
+server = HTTPServer(("127.0.0.1", int(sys.argv[1])), Handler)
+server.serve_forever()
+PY
+
+python3 "$TMP_DIR/mock-openai-effort.py" "$OPENAI_PORT" &
+OPENAI_PID=$!
+sleep 1
+
+node ./bin/gaia.js init --force >/dev/null
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+cfg_path = Path(os.environ["GAIA_ASSISTANT_HOME"]) / "config.json"
+cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+reasoning = cfg.setdefault("reasoning", {})
+reasoning["provider"] = "openai"
+reasoning["model"] = "gpt-5.3-codex"
+reasoning["effort"] = "high"
+reasoning["explicit_provider_override"] = True
+cfg_path.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+PY
+
+run_supported="$(
+  OPENAI_API_KEY="test-openai-key" \
+  OPENAI_BASE_URL="http://127.0.0.1:${OPENAI_PORT}/v1" \
+  node ./bin/gaia.js run --mode single 2>&1
+)"
+
+[[ "$run_supported" == *"Reasoning provider: openai (from launcher config)"* ]]
+[[ "$run_supported" == *"Reasoning model: gpt-5.3-codex (from launcher config)"* ]]
+[[ "$run_supported" == *"Reasoning effort: high (from launcher config)"* ]]
+[[ "$run_supported" == *"Applied reasoning effort: provider=openai model=gpt-5.3-codex effort=high"* ]]
+[[ "$run_supported" == *"No actions proposed this cycle."* ]]
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+cfg_path = Path(os.environ["GAIA_ASSISTANT_HOME"]) / "config.json"
+cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+reasoning = cfg.setdefault("reasoning", {})
+reasoning["provider"] = "openai"
+reasoning["model"] = "gpt-4.1-mini"
+reasoning["effort"] = "high"
+reasoning["explicit_provider_override"] = True
+cfg_path.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+PY
+
+run_unsupported="$(
+  OPENAI_API_KEY="test-openai-key" \
+  OPENAI_BASE_URL="http://127.0.0.1:${OPENAI_PORT}/v1" \
+  node ./bin/gaia.js run --mode single 2>&1
+)"
+
+[[ "$run_unsupported" == *"Reasoning provider: openai (from launcher config)"* ]]
+[[ "$run_unsupported" == *"Reasoning model: gpt-4.1-mini (from launcher config)"* ]]
+[[ "$run_unsupported" == *"Reasoning effort: high (from launcher config)"* ]]
+[[ "$run_unsupported" == *"Reasoning effort not applied: provider=openai model=gpt-4.1-mini effort=high (unsupported provider/model)"* ]]
+[[ "$run_unsupported" == *"No actions proposed this cycle."* ]]


### PR DESCRIPTION
## Summary
- Add normalized reasoning effort contract (`reasoning.effort`) with values `minimal|low|medium|high` and `auto` as explicit no-effort mode for CLI overrides.
- Extend onboarding/runtime/config command surfaces:
  - `gaia onboard --effort ...`
  - `gaia run --reasoning-effort ...`
  - `gaia config set/get effort`
- Propagate effort to provider payloads only when supported:
  - OpenAI: `reasoning_effort`
  - OpenRouter: `reasoning.effort`
  - Anthropic: adaptive-thinking effort only for supported models
- Emit deterministic runtime logs when effort is not applied for unsupported provider/model paths.
- Add deterministic runtime/UAT coverage and governance record for effort behavior.

## Track Declaration
- [x] `assistant-track`
- [ ] `framework-track`
- [ ] Cross-track (`assistant-track` + `framework-track`)

## Risk Level
- [ ] Low
- [x] Medium
- [ ] High (requires explicit maintainer review before merge)

## Self-Evolution Applicability
- [ ] Applies: this PR changes self-evolution behavior/governance.
- [x] Not applicable: no self-evolution behavior/governance changes.

## Self-Evolution Evidence (required when applicability is "Applies")
- Baseline evidence: N/A
- Delta observed: N/A
- Thresholds and guardrails: N/A
- Rollback/fallback: N/A
- Risk notes: N/A

## Validation
- [x] `make check-all`
- [x] `make test-smoke` (if assistant/runtime behavior changed)
- [x] `make test-uat` (required for assistant feature changes)
- [x] Additional targeted checks documented below

Additional targeted checks:
- `python3 -m py_compile tools/gaia-assistant.py tools/gaia_assistant_parser.py tools/gaia_assistant_onboarding.py tools/agent-loop.py`
- `GAIA_ASSISTANT_HOME="$(mktemp -d)" bash ./tools/runtime-effort-check.sh`
- `GAIA_ASSISTANT_HOME="$(mktemp -d)" bash ./tools/runtime-failover-check.sh`
- `python3 tools/check-uat-policy.py --base-ref origin/main --reviewer TonyThePredictor`

## Checklist
- [x] Changes are small, safe, and incremental
- [x] No breaking changes to structure or website
- [x] Docs follow repo markdown standards
- [x] Links added/updated were verified
- [x] Track and risk are declared
- [x] Self-evolution applicability declared and rubric completed when required
- [x] Handoff notes included (files changed, validations, follow-ups)
- [x] New feature surfaces include UAT updates in this PR

## UAT Change Justification
This PR updates protected UAT governance files because `#147` adds new command-surface behavior and runtime request-contract behavior.

- Why needed: without new coverage, regressions in effort persistence/override and provider/model support gating could silently ship.
- What changed:
  - `assistant/feature-catalog.json` maps `run` to new effort selector scenario.
  - `assistant/uat-scenarios.json` adds `run_reasoning_effort_selector` and strengthens onboarding verification for `--effort` persistence.
  - `tools/runtime-effort-check.sh` provides deterministic local mock assertions for both supported payload propagation and unsupported-path no-op behavior.
- Risk: medium (runtime behavior changes with explicit guardrails and deterministic tests).
- Confidence: local/offline deterministic mocks enforce payload correctness and unsupported-path behavior; smoke/UAT/check-all all pass.
- Governance record: `docs/uat-changes/2026-02-15-reasoning-effort-selector-coverage.md`.

## Notes
- Closes #147.
- Sub-role evidence:
  - `gaia-researcher`: provider payload contracts aligned to official docs for OpenAI/OpenRouter/Anthropic effort semantics and model-support caveats.
  - `gaia-qa-evaluator`: pass/go decision with passing targeted checks + smoke (`27/27`) + UAT (`49/49`) + `check-all`.
  - `gaia-technical-writer`: docs and state surfaces updated (`assistant/README.md`, `STATUS.md`, `CHANGELOG.md`).
- State sync:
  - `STATUS.md` updated.
  - `CHANGELOG.md` updated.
  - `ROADMAP.md` unchanged (no dependency/phase ordering delta in this lane).
- No architecture delta.
