### PR TITLE
feat(models): expose capability metadata in gaia models list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- Model capability metadata in `gaia models list` outputs (`supports_effort`, `effort_levels`, `capability_source`) with deterministic provider/model derivation rules (`#154`)
+- Deterministic UAT coverage for model capability metadata output contract (`models_list_capability_metadata`) and governance record (`docs/uat-changes/2026-02-15-model-capability-metadata-coverage.md`) (`#154`)
 - Provider-aware reasoning effort selector across onboarding/config/runtime (`reasoning.effort`, `gaia onboard --effort`, `gaia run --reasoning-effort`) with deterministic runtime payload mapping for supported provider/model combinations (`#147`)
 - Deterministic runtime effort regression check harness and UAT scenario/governance coverage (`tools/runtime-effort-check.sh`, `assistant/uat-scenarios.json`, `assistant/feature-catalog.json`, `docs/uat-changes/2026-02-15-reasoning-effort-selector-coverage.md`, `#147`)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -33,14 +33,13 @@ current active sprint window.
 
 ## In Progress
 
-_Nothing in progress._
+- `#154` `[Sprint][Assistant] Expose model capability metadata in gaia models list` (@nunopratas)
 
 ## Next Up (Ordered Queue)
 
-1. `#154` `[Sprint][Assistant] Expose model capability metadata in gaia models list`
-2. `#155` `[Sprint][Assistant] Add onboarding compatibility guardrails for model and effort`
-3. `#157` `[Sprint][Framework] Phase 4 kickoff: delegation contract and coordinator design`
-4. `#156` `[Sprint][Framework] Prepare npm release @gaia-minds/assistant-cli@0.5.0`
+1. `#155` `[Sprint][Assistant] Add onboarding compatibility guardrails for model and effort`
+2. `#157` `[Sprint][Framework] Phase 4 kickoff: delegation contract and coordinator design`
+3. `#156` `[Sprint][Framework] Prepare npm release @gaia-minds/assistant-cli@0.5.0`
 
 ## Planned Next Wave
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -102,7 +102,9 @@ The wizard lets you choose provider and connection style:
 For model selection, Gaia tries to load a live provider catalog when credentials
 are available (OpenAI, Anthropic, OpenRouter) and falls back to a curated list
 when live catalog retrieval is not possible (for example Codex/Claude CLI-only
-OAuth flows). You can always bypass prompts with `--model <model-id>`.
+OAuth flows). `gaia models list` now includes normalized capability metadata
+(`supports_effort`, `effort_levels`) for each listed model. You can always
+bypass prompts with `--model <model-id>`.
 
 To inspect model catalogs before onboarding or config changes:
 

--- a/assistant/feature-catalog.json
+++ b/assistant/feature-catalog.json
@@ -5,7 +5,7 @@
     {"path": "init", "scenarios": ["init_force"]},
     {"path": "onboard", "scenarios": ["onboard_openai_nostore", "onboard_claude_code_oauth"]},
     {"path": "models", "scenarios": ["models_list_source_disclosure"]},
-    {"path": "models list", "scenarios": ["models_list_source_disclosure"]},
+    {"path": "models list", "scenarios": ["models_list_source_disclosure", "models_list_capability_metadata"]},
     {"path": "doctor", "scenarios": ["doctor_command"]},
     {"path": "config", "scenarios": ["cli_help_surface"]},
     {"path": "config set", "scenarios": ["config_set_get_name", "provider_twin_openai", "signals_extraction_privacy_controls", "signals_skill_first_triage_matrix", "skills_provenance_admission_modes", "skills_obfuscation_validation_hardening"]},

--- a/assistant/uat-scenarios.json
+++ b/assistant/uat-scenarios.json
@@ -34,6 +34,12 @@
       "command": "json=$(node ./bin/gaia.js models list --provider openai-codex --json) && source=$(printf '%s' \"$json\" | python3 -c \"import json,sys; payload=json.load(sys.stdin); print(payload.get('source', ''))\") && [[ \"$source\" == \"live\" || \"$source\" == \"curated\" ]] && model0=$(printf '%s' \"$json\" | python3 -c \"import json,sys; payload=json.load(sys.stdin); models=payload.get('models', []); print(models[0] if models else '')\") && [[ \"$model0\" == \"gpt-5.3-codex\" ]] && text=$(node ./bin/gaia.js models list --provider openai-codex) && [[ \"$text\" == *\"provider: openai-codex\"* ]] && [[ \"$text\" == *\"source:\"* ]]"
     },
     {
+      "id": "models_list_capability_metadata",
+      "description": "Model catalog JSON/text surfaces include normalized effort capability metadata",
+      "expect_exit": 0,
+      "command": "json=$(node ./bin/gaia.js models list --provider openai-codex --json) && capability_ok=$(printf '%s' \"$json\" | python3 -c \"import json,sys; payload=json.load(sys.stdin); models=payload.get('models', []); caps=payload.get('model_capabilities', []); ok=bool(models) and bool(caps) and isinstance(caps[0].get('supports_effort', None), bool) and isinstance(caps[0].get('effort_levels', None), list) and caps[0].get('id')==models[0]; print('ok' if ok else 'bad')\") && [[ \"$capability_ok\" == \"ok\" ]] && text=$(node ./bin/gaia.js models list --provider openai-codex) && [[ \"$text\" == *\"capability source:\"* ]] && [[ \"$text\" == *\"effort:\"* ]]"
+    },
+    {
       "id": "doctor_command",
       "description": "Doctor command runs without blocking errors",
       "expect_exit": 0,

--- a/docs/uat-changes/2026-02-15-model-capability-metadata-coverage.md
+++ b/docs/uat-changes/2026-02-15-model-capability-metadata-coverage.md
@@ -1,0 +1,41 @@
+# Model Capability Metadata Coverage UAT Update (2026-02-15)
+
+## Why this change
+
+Issue `#154` extends `gaia models list` output contract with capability metadata
+(`supports_effort`, `effort_levels`) and capability provenance reporting. This
+lane updates protected UAT governance files so the command-surface contract is
+deterministically covered.
+
+Updated mapping:
+
+- `models list` now includes `models_list_capability_metadata` in addition to
+  existing source-disclosure coverage.
+
+New scenario:
+
+- `models_list_capability_metadata`
+
+The new scenario validates JSON schema presence/type for capability metadata and
+text output disclosure (`capability source`, `effort:` markers).
+
+## Risk
+
+- Medium.
+- Contract drift in model-catalog output could break downstream selectors or
+  hide capability assumptions if untested.
+
+## Confidence and Safeguards
+
+- Coverage is deterministic/local and reuses existing command path.
+- Assertions verify both machine-readable and human-readable output contracts.
+- Existing source-disclosure scenario remains active for backward contract
+  confidence.
+
+## Validation
+
+- `python3 -m py_compile tools/gaia-assistant.py tools/gaia_assistant_parser.py tools/gaia_assistant_onboarding.py`
+- `make test-smoke`
+- `make test-uat`
+- `make check-all`
+- `python3 tools/check-uat-policy.py --base-ref origin/main --reviewer TonyThePredictor`

--- a/tools/gaia-assistant.py
+++ b/tools/gaia-assistant.py
@@ -4730,6 +4730,48 @@ def _provider_model_catalog(provider: str, api_key: str) -> Tuple[List[str], str
     return fallback, "curated catalog"
 
 
+def _openai_model_supports_effort(model_id: str) -> bool:
+    normalized = str(model_id).strip().lower()
+    return normalized.startswith(("gpt-5", "o1", "o3", "o4"))
+
+
+def _openrouter_model_supports_effort(model_id: str) -> bool:
+    normalized = str(model_id).strip().lower()
+    if not normalized or normalized == "openrouter/auto":
+        return False
+    markers = ("gpt-5", "o1", "o3", "o4", "grok", "claude-opus-4-6")
+    return any(marker in normalized for marker in markers)
+
+
+def _anthropic_model_supports_effort(model_id: str) -> bool:
+    normalized = str(model_id).strip().lower()
+    return "claude-opus-4-6" in normalized
+
+
+def _model_capability_entry(provider: str, model_id: str, capability_source: str) -> Dict[str, Any]:
+    supports_effort = False
+    effort_levels: List[str] = []
+    if provider in ("openai", "openai-codex"):
+        supports_effort = _openai_model_supports_effort(model_id)
+        if supports_effort:
+            effort_levels = list(REASONING_EFFORT_CHOICES)
+    elif provider == "openrouter":
+        supports_effort = _openrouter_model_supports_effort(model_id)
+        if supports_effort:
+            effort_levels = list(REASONING_EFFORT_CHOICES)
+    elif provider in ("anthropic", "claude-code"):
+        supports_effort = _anthropic_model_supports_effort(model_id)
+        if supports_effort:
+            effort_levels = ["low", "medium", "high"]
+
+    return {
+        "id": model_id,
+        "supports_effort": supports_effort,
+        "effort_levels": effort_levels,
+        "capability_source": capability_source,
+    }
+
+
 def _provider_model_catalog_snapshot(
     provider: str,
     *,
@@ -4747,6 +4789,11 @@ def _provider_model_catalog_snapshot(
     source = "live" if source_detail.startswith("live") else "curated"
     default_model = _default_model_for_provider(provider)
     ordered_models = _dedupe_models([default_model, *catalog], limit=PROVIDER_MODEL_CATALOG_LIMIT)
+    capability_source = "derived-provider-contract-v1"
+    model_capabilities = [
+        _model_capability_entry(provider, model_id, capability_source)
+        for model_id in ordered_models
+    ]
     fallback_reason = ""
     guidance = ""
 
@@ -4777,6 +4824,8 @@ def _provider_model_catalog_snapshot(
         "guidance": guidance,
         "default_model": default_model,
         "models": ordered_models,
+        "capability_source": capability_source,
+        "model_capabilities": model_capabilities,
     }
 
 
@@ -5144,9 +5193,20 @@ def cmd_models_list(args: argparse.Namespace) -> int:
         guidance = str(entry.get("guidance", "")).strip()
         default_model = str(entry.get("default_model", "")).strip()
         models = [str(item).strip() for item in entry.get("models", []) if str(item).strip()]
+        capability_source = str(entry.get("capability_source", "derived-provider-contract-v1")).strip()
+        capabilities_raw = entry.get("model_capabilities", [])
+        capabilities_raw = capabilities_raw if isinstance(capabilities_raw, list) else []
+        capabilities: Dict[str, Dict[str, Any]] = {}
+        for item in capabilities_raw:
+            if not isinstance(item, dict):
+                continue
+            model_id = str(item.get("id", "")).strip()
+            if model_id:
+                capabilities[model_id] = item
 
         print(f"provider: {provider} ({provider_label})")
         print(f"source:   {source} ({source_detail})")
+        print(f"capability source: {capability_source}")
         if fallback_reason:
             print(f"reason:   {fallback_reason}")
         if guidance:
@@ -5154,7 +5214,15 @@ def cmd_models_list(args: argparse.Namespace) -> int:
         print("models:")
         for model in models:
             marker = " (recommended)" if model == default_model else ""
-            print(f"  - {model}{marker}")
+            capability = capabilities.get(model, {})
+            supports_effort = bool(capability.get("supports_effort", False))
+            effort_levels_raw = capability.get("effort_levels", [])
+            effort_levels_raw = effort_levels_raw if isinstance(effort_levels_raw, list) else []
+            effort_levels = [str(level).strip() for level in effort_levels_raw if str(level).strip()]
+            effort_note = "unsupported"
+            if supports_effort and effort_levels:
+                effort_note = ",".join(effort_levels)
+            print(f"  - {model}{marker} [effort: {effort_note}]")
     return 0
 
 


### PR DESCRIPTION
## Summary
- Extend `gaia models list` output contract with model capability metadata:
  - `model_capabilities[]` in JSON output
  - per-model effort capability rendering in text output
  - capability provenance disclosure (`capability_source`)
- Add deterministic provider/model capability derivation for effort support and supported effort levels.
- Update docs and UAT governance/coverage for the enriched `models list` contract.

## Track Declaration
- [x] `assistant-track`
- [ ] `framework-track`
- [ ] Cross-track (`assistant-track` + `framework-track`)

## Risk Level
- [ ] Low
- [x] Medium
- [ ] High (requires explicit maintainer review before merge)

## Self-Evolution Applicability
- [ ] Applies: this PR changes self-evolution behavior/governance.
- [x] Not applicable: no self-evolution behavior/governance changes.

## Self-Evolution Evidence (required when applicability is "Applies")
- Baseline evidence: N/A
- Delta observed: N/A
- Thresholds and guardrails: N/A
- Rollback/fallback: N/A
- Risk notes: N/A

## Validation
- [x] `make check-all`
- [x] `make test-smoke` (if assistant/runtime behavior changed)
- [x] `make test-uat` (required for assistant feature changes)
- [x] Additional targeted checks documented below

Additional targeted checks:
- `python3 -m py_compile tools/gaia-assistant.py tools/gaia_assistant_parser.py tools/gaia_assistant_onboarding.py`
- `gaia models list --provider openai-codex --json` capability schema assertion
- `gaia models list --provider openai-codex` text capability rendering assertion
- `python3 tools/check-uat-policy.py --base-ref origin/main --reviewer TonyThePredictor`

## Checklist
- [x] Changes are small, safe, and incremental
- [x] No breaking changes to structure or website
- [x] Docs follow repo markdown standards
- [x] Links added/updated were verified
- [x] Track and risk are declared
- [x] Self-evolution applicability declared and rubric completed when required
- [x] Handoff notes included (files changed, validations, follow-ups)
- [x] New feature surfaces include UAT updates in this PR

## UAT Change Justification
This PR updates protected UAT governance files because `gaia models list` command output contract gained new capability metadata fields/surfaces.

- Why needed: without explicit coverage, regressions could remove or reshape capability metadata (`supports_effort`, `effort_levels`) and break downstream selector assumptions.
- What changed:
  - `assistant/feature-catalog.json`: `models list` now maps to `models_list_capability_metadata`.
  - `assistant/uat-scenarios.json`: add deterministic scenario asserting capability metadata schema + text disclosure.
  - governance record: `docs/uat-changes/2026-02-15-model-capability-metadata-coverage.md`.
- Risk: medium, output-contract change on an operator-facing command.
- Confidence: smoke/UAT/check-all pass, and scenario verifies both machine-readable and human-readable contracts.

## Notes
- Closes #154.
- Sub-role evidence:
  - `gaia-researcher`: capability derivation rules align with provider-contract constraints from `#144`.
  - `gaia-qa-evaluator`: pass/go from green smoke (`27/27`), UAT (`50/50`), and policy/check-all gates.
  - `gaia-technical-writer`: docs and changelog updates included.
- State sync:
  - `STATUS.md` updated (`#154` marked in progress).
  - `ROADMAP.md` unchanged (queue/ordering unchanged in this lane).
  - `CHANGELOG.md` updated (Unreleased additions for this feature).
- No architecture delta.
