### PR TITLE
feat: add onboarding and run compatibility guardrails for model effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - Model capability metadata in `gaia models list` outputs (`supports_effort`, `effort_levels`, `capability_source`) with deterministic provider/model derivation rules (`#154`)
 - Deterministic UAT coverage for model capability metadata output contract (`models_list_capability_metadata`) and governance record (`docs/uat-changes/2026-02-15-model-capability-metadata-coverage.md`) (`#154`)
+- Deterministic onboarding compatibility guardrails for unsupported model+effort selections with explicit remediation guidance (`#155`)
+- Deterministic UAT coverage for onboarding/run compatibility warning surfaces (`onboard_effort_compatibility_warning`, `tools/runtime-effort-check.sh`) and governance record (`docs/uat-changes/2026-02-15-onboarding-effort-compatibility-guardrails.md`) (`#155`)
 - Provider-aware reasoning effort selector across onboarding/config/runtime (`reasoning.effort`, `gaia onboard --effort`, `gaia run --reasoning-effort`) with deterministic runtime payload mapping for supported provider/model combinations (`#147`)
 - Deterministic runtime effort regression check harness and UAT scenario/governance coverage (`tools/runtime-effort-check.sh`, `assistant/uat-scenarios.json`, `assistant/feature-catalog.json`, `docs/uat-changes/2026-02-15-reasoning-effort-selector-coverage.md`, `#147`)
 
 ### Changed
 - `gaia run` startup output now reports effective reasoning effort and agent-loop logs explicit effort no-op behavior for unsupported provider/model paths (`#147`)
+- `gaia run` startup now emits deterministic compatibility warnings before execution when configured/overridden effort is unsupported for the selected model (`#155`)
 
 ### Removed
 - _Nothing yet._

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -228,17 +228,16 @@ Recommended merge order:
 
 Execution queue (post-effort-selector planning round; opened February 15, 2026):
 
-- `#154` Expose model capability metadata in `gaia models list`
+- `#154` Expose model capability metadata in `gaia models list` (delivered; PR #159)
 - `#155` Add onboarding compatibility guardrails for model+effort combinations
 - `#157` Phase 4 kickoff: delegation contract and coordinator design
 - `#156` Prepare npm release `@gaia-minds/assistant-cli@0.5.0`
 
 Recommended merge order:
 
-1. `#154` capability metadata contract
-2. `#155` compatibility guardrails (reusing `#154` outputs)
-3. `#157` Phase 4 kickoff design lane (parallel-safe)
-4. `#156` release lane after stabilization lanes are merged
+1. `#155` compatibility guardrails (reusing `#154` outputs)
+2. `#157` Phase 4 kickoff design lane (parallel-safe)
+3. `#156` release lane after stabilization lanes are merged
 
 Planning artifact:
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -30,16 +30,17 @@ current active sprint window.
 - `Sprint live preview rebuild from executable Gaia traces` (`#132`)
 - npm release `@gaia-minds/assistant-cli@0.4.0` (`#133`, tag `v0.4.0`)
 - `[Sprint][Assistant] Add model effort selector across onboarding/config/runtime` (`#147`)
+- `[Sprint][Assistant] Expose model capability metadata in gaia models list` (`#154`, PR #159)
+- `[Sprint][Assistant] Add onboarding compatibility guardrails for model and effort` (`#155`)
 
 ## In Progress
 
-- `#154` `[Sprint][Assistant] Expose model capability metadata in gaia models list` (@nunopratas)
+_No active in-progress lane._
 
 ## Next Up (Ordered Queue)
 
-1. `#155` `[Sprint][Assistant] Add onboarding compatibility guardrails for model and effort`
-2. `#157` `[Sprint][Framework] Phase 4 kickoff: delegation contract and coordinator design`
-3. `#156` `[Sprint][Framework] Prepare npm release @gaia-minds/assistant-cli@0.5.0`
+1. `#157` `[Sprint][Framework] Phase 4 kickoff: delegation contract and coordinator design`
+2. `#156` `[Sprint][Framework] Prepare npm release @gaia-minds/assistant-cli@0.5.0`
 
 ## Planned Next Wave
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -835,6 +835,8 @@ Reasoning effort selector:
 - Config contract: `reasoning.effort` (`minimal`, `low`, `medium`, `high`).
 - Onboarding supports `--effort` and run supports `--reasoning-effort`.
 - `gaia config set effort <value>` persists effort (`gaia config get effort`).
+- Onboarding and `gaia run` startup now emit deterministic compatibility
+  warnings/remediation guidance when selected model+effort is unsupported.
 - Runtime applies effort only when the current provider/model supports it and
   logs explicit no-op behavior when unsupported.
 

--- a/assistant/feature-catalog.json
+++ b/assistant/feature-catalog.json
@@ -3,7 +3,7 @@
   "description": "Feature-to-UAT coverage map for Gaia assistant and evolution actions.",
   "commands": [
     {"path": "init", "scenarios": ["init_force"]},
-    {"path": "onboard", "scenarios": ["onboard_openai_nostore", "onboard_claude_code_oauth"]},
+    {"path": "onboard", "scenarios": ["onboard_openai_nostore", "onboard_effort_compatibility_warning", "onboard_claude_code_oauth"]},
     {"path": "models", "scenarios": ["models_list_source_disclosure"]},
     {"path": "models list", "scenarios": ["models_list_source_disclosure", "models_list_capability_metadata"]},
     {"path": "doctor", "scenarios": ["doctor_command"]},

--- a/assistant/uat-scenarios.json
+++ b/assistant/uat-scenarios.json
@@ -22,6 +22,12 @@
       "command": "node ./bin/gaia.js onboard --provider openai --api-key test-key --model gpt-4.1-mini --effort high --yes --no-store-api-key >/dev/null && effort=$(node ./bin/gaia.js config get effort) && [[ \"$effort\" == \"high\" ]]"
     },
     {
+      "id": "onboard_effort_compatibility_warning",
+      "description": "Onboarding emits deterministic compatibility guidance when model+effort is unsupported",
+      "expect_exit": 0,
+      "command": "out=$(node ./bin/gaia.js onboard --provider openai --api-key test-key --model gpt-4.1-mini --effort high --yes --no-store-api-key 2>&1) && [[ \"$out\" == *\"[warn] onboarding compatibility: effort 'high' is unsupported for openai/gpt-4.1-mini.\"* ]] && [[ \"$out\" == *\"runtime will ignore this effort value and use provider/model defaults.\"* ]] && [[ \"$out\" == *\"models list --provider openai\"* ]]"
+    },
+    {
       "id": "onboard_claude_code_oauth",
       "description": "Claude Code OAuth onboarding path links metadata deterministically",
       "expect_exit": 0,

--- a/docs/uat-changes/2026-02-15-onboarding-effort-compatibility-guardrails.md
+++ b/docs/uat-changes/2026-02-15-onboarding-effort-compatibility-guardrails.md
@@ -1,0 +1,35 @@
+# Onboarding Effort Compatibility Guardrails UAT Update (2026-02-15)
+
+## Why this change
+
+Issue `#155` adds deterministic compatibility guardrails so onboarding and run
+startup clearly disclose unsupported model+effort combinations before cycle
+execution. Runtime behavior remains no-op for unsupported paths, but user
+guidance is now explicit.
+
+Updated mappings:
+
+- `onboard` now includes `onboard_effort_compatibility_warning` coverage.
+- Existing runtime selector scenario (`run_reasoning_effort_selector`) now
+  asserts startup compatibility warning/remediation text for unsupported paths.
+
+## Risk
+
+- Medium.
+- If warning text drifts or disappears, users may incorrectly assume effort is
+  being applied for unsupported model/provider pairs.
+
+## Confidence and Safeguards
+
+- Coverage remains deterministic/local with no external API dependency.
+- Assertions validate both onboarding and run startup warning contracts.
+- Existing runtime selector checks still verify applied/no-op behavior in
+  agent-loop logs.
+
+## Validation
+
+- `python3 -m py_compile tools/gaia-assistant.py tools/agent-loop.py`
+- `make test-smoke`
+- `make test-uat`
+- `make check-all`
+- `python3 tools/check-uat-policy.py --base-ref origin/main --reviewer TonyThePredictor`

--- a/tools/gaia-assistant.py
+++ b/tools/gaia-assistant.py
@@ -4772,6 +4772,85 @@ def _model_capability_entry(provider: str, model_id: str, capability_source: str
     }
 
 
+def _reasoning_effort_compatibility(provider: str, model_id: str, effort: str) -> Dict[str, Any]:
+    normalized_provider = str(provider).strip().lower()
+    normalized_model = str(model_id).strip()
+    requested_effort = _normalize_reasoning_effort(effort, default_value="")
+    capability = _model_capability_entry(normalized_provider, normalized_model, "derived-provider-contract-v1")
+    supports_effort = bool(capability.get("supports_effort", False))
+    effort_levels_raw = capability.get("effort_levels", [])
+    effort_levels_raw = effort_levels_raw if isinstance(effort_levels_raw, list) else []
+    effort_levels: List[str] = []
+    for level in effort_levels_raw:
+        normalized_level = _normalize_reasoning_effort(level, default_value="__invalid__")
+        if normalized_level == "__invalid__":
+            continue
+        if normalized_level and normalized_level not in effort_levels:
+            effort_levels.append(normalized_level)
+
+    mapped_effort = requested_effort
+    if normalized_provider in ("anthropic", "claude-code") and mapped_effort == "minimal":
+        mapped_effort = "low"
+
+    compatible = True
+    if requested_effort:
+        if not supports_effort:
+            compatible = False
+        elif effort_levels and mapped_effort not in effort_levels:
+            compatible = False
+
+    return {
+        "provider": normalized_provider,
+        "model": normalized_model,
+        "requested_effort": requested_effort,
+        "mapped_effort": mapped_effort,
+        "supports_effort": supports_effort,
+        "effort_levels": effort_levels,
+        "compatible": compatible,
+    }
+
+
+def _print_reasoning_effort_compatibility_warning(
+    *,
+    stage: str,
+    provider: str,
+    model_id: str,
+    effort: str,
+) -> bool:
+    compatibility = _reasoning_effort_compatibility(provider, model_id, effort)
+    requested_effort = str(compatibility.get("requested_effort", "")).strip()
+    if not requested_effort:
+        return False
+    if bool(compatibility.get("compatible", True)):
+        return False
+
+    normalized_provider = str(compatibility.get("provider", "")).strip().lower() or str(provider).strip().lower()
+    normalized_model = str(compatibility.get("model", "")).strip() or str(model_id).strip()
+    if not normalized_provider or not normalized_model:
+        return False
+    effort_levels_raw = compatibility.get("effort_levels", [])
+    effort_levels_raw = effort_levels_raw if isinstance(effort_levels_raw, list) else []
+    effort_levels = [str(level).strip() for level in effort_levels_raw if str(level).strip()]
+    effort_levels_display = ",".join(effort_levels) if effort_levels else "none"
+    provider_hint = normalized_provider or "openai"
+
+    print(
+        f"[warn] {stage} compatibility: effort '{requested_effort}' is unsupported for "
+        f"{normalized_provider}/{normalized_model}."
+    )
+    print(
+        f"[warn] {stage} compatibility: runtime will ignore this effort value and use provider/model defaults."
+    )
+    print(
+        f"[hint] {stage} compatibility: supported effort levels for this model: {effort_levels_display}."
+    )
+    print(
+        f"[hint] {stage} compatibility: run `{_launcher_hint()} models list --provider {provider_hint}` "
+        "to choose a compatible model, or set effort to auto."
+    )
+    return True
+
+
 def _provider_model_catalog_snapshot(
     provider: str,
     *,
@@ -5431,6 +5510,12 @@ def cmd_onboard(args: argparse.Namespace) -> int:
             secret_store_override=args.secret_store,
             non_interactive=args.yes,
         )
+        _print_reasoning_effort_compatibility_warning(
+            stage="onboarding",
+            provider=provider,
+            model_id=selected_model,
+            effort=selected_effort,
+        )
         print("OAuth flow selected: OpenAI Codex via Codex CLI")
         print("This opens browser/device auth and links profile into Gaia local auth store.")
         should_start = _prompt_yes_no(
@@ -5463,6 +5548,12 @@ def cmd_onboard(args: argparse.Namespace) -> int:
             explicit_api_key=args.api_key,
             secret_store_override=args.secret_store,
             non_interactive=args.yes,
+        )
+        _print_reasoning_effort_compatibility_warning(
+            stage="onboarding",
+            provider=provider,
+            model_id=selected_model,
+            effort=selected_effort,
         )
         print("OAuth flow selected: Claude Code via Claude CLI")
         print("This runs Claude auth login and links profile metadata into Gaia local auth store.")
@@ -5505,6 +5596,12 @@ def cmd_onboard(args: argparse.Namespace) -> int:
         explicit_api_key=args.api_key,
         secret_store_override=args.secret_store,
         non_interactive=args.yes,
+    )
+    _print_reasoning_effort_compatibility_warning(
+        stage="onboarding",
+        provider=provider,
+        model_id=provider_model,
+        effort=selected_effort,
     )
 
     rc = _configure_api_key_provider(
@@ -13095,6 +13192,12 @@ def cmd_run(args: argparse.Namespace) -> int:
         print(f"Reasoning effort override: {_reasoning_effort_display(effective_effort)}")
     else:
         print(f"Reasoning effort: {_reasoning_effort_display(configured_effort)} (from launcher config)")
+    _print_reasoning_effort_compatibility_warning(
+        stage="run startup",
+        provider=effective_provider,
+        model_id=effective_model,
+        effort=effective_effort,
+    )
     print(
         "Reasoning failover: "
         f"{'enabled' if failover_enabled else 'disabled'} "

--- a/tools/runtime-effort-check.sh
+++ b/tools/runtime-effort-check.sh
@@ -139,6 +139,7 @@ run_supported="$(
 [[ "$run_supported" == *"Reasoning provider: openai (from launcher config)"* ]]
 [[ "$run_supported" == *"Reasoning model: gpt-5.3-codex (from launcher config)"* ]]
 [[ "$run_supported" == *"Reasoning effort: high (from launcher config)"* ]]
+[[ "$run_supported" != *"run startup compatibility: effort"* ]]
 [[ "$run_supported" == *"Applied reasoning effort: provider=openai model=gpt-5.3-codex effort=high"* ]]
 [[ "$run_supported" == *"No actions proposed this cycle."* ]]
 
@@ -166,5 +167,8 @@ run_unsupported="$(
 [[ "$run_unsupported" == *"Reasoning provider: openai (from launcher config)"* ]]
 [[ "$run_unsupported" == *"Reasoning model: gpt-4.1-mini (from launcher config)"* ]]
 [[ "$run_unsupported" == *"Reasoning effort: high (from launcher config)"* ]]
+[[ "$run_unsupported" == *"[warn] run startup compatibility: effort 'high' is unsupported for openai/gpt-4.1-mini."* ]]
+[[ "$run_unsupported" == *"[warn] run startup compatibility: runtime will ignore this effort value and use provider/model defaults."* ]]
+[[ "$run_unsupported" == *"[hint] run startup compatibility: run"*"--provider openai"* ]]
 [[ "$run_unsupported" == *"Reasoning effort not applied: provider=openai model=gpt-4.1-mini effort=high (unsupported provider/model)"* ]]
 [[ "$run_unsupported" == *"No actions proposed this cycle."* ]]


### PR DESCRIPTION
## Summary
- add deterministic model+effort compatibility evaluation in launcher surfaces
- emit explicit onboarding warning/remediation when selected model does not support requested effort
- emit explicit `gaia run` startup warning/remediation before execution when configured/override effort is unsupported
- preserve runtime behavior (effort remains no-op for unsupported provider/model paths)
- extend UAT coverage + policy/governance record for onboarding/run compatibility warning contract

Closes #155.

## Track Declaration
- [x] `assistant-track`
- [ ] `framework-track`
- [ ] Cross-track (`assistant-track` + `framework-track`)

## Risk Level
- [ ] Low
- [x] Medium
- [ ] High (requires explicit maintainer review before merge)

## Self-Evolution Applicability
- [ ] Applies: this PR changes self-evolution behavior/governance.
- [x] Not applicable: no self-evolution behavior/governance changes.

## Self-Evolution Evidence (required when applicability is "Applies")
- Baseline evidence:
- Delta observed:
- Thresholds and guardrails:
- Rollback/fallback:
- Risk notes:

## Validation
- [x] `make check-all`
- [x] `make test-smoke` (if assistant/runtime behavior changed)
- [x] `make test-uat` (required for assistant feature changes)
- [x] Additional targeted checks documented below

Additional targeted checks:
- `python3 -m py_compile tools/gaia-assistant.py tools/agent-loop.py tools/gaia_assistant_parser.py tools/gaia_assistant_onboarding.py`
- targeted onboarding warning check (`gaia onboard --provider openai --model gpt-4.1-mini --effort high --yes --no-store-api-key`)
- targeted run startup warning check (`gaia run --mode single --dry-run --reasoning-provider openai --reasoning-model gpt-4.1-mini --reasoning-effort high`)
- `python3 tools/check-uat-policy.py --base-ref origin/main --reviewer TonyThePredictor`

## Checklist
- [x] Changes are small, safe, and incremental
- [x] No breaking changes to structure or website
- [x] Docs follow repo markdown standards
- [x] Links added/updated were verified
- [x] Track and risk are declared
- [x] Self-evolution applicability declared and rubric completed when required
- [x] Handoff notes included (files changed, validations, follow-ups)
- [x] New feature surfaces include UAT updates in this PR

## UAT Change Justification
- Added `onboard_effort_compatibility_warning` to enforce deterministic pre-run compatibility warnings in onboarding.
- Extended runtime effort harness assertions (`tools/runtime-effort-check.sh`) to lock startup warning/remediation contract in unsupported paths.
- Risk is medium because warning drift can silently regress UX clarity while runtime stays no-op; confidence is maintained with deterministic local assertions in both onboarding and runtime surfaces plus policy gate pass.
- Governance record added: `docs/uat-changes/2026-02-15-onboarding-effort-compatibility-guardrails.md`.

## Notes
- Main role: `contributor`
- Sub-roles executed: `gaia-qa-evaluator`, `gaia-technical-writer`
- State sync updated: `STATUS.md`, `ROADMAP.md`, `CHANGELOG.md`
- No architecture delta.
